### PR TITLE
Fix stale object being stored and preventing up to date recomposition in list detail pane (fixes #17)

### DIFF
--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/component/tasksUI.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/component/tasksUI.kt
@@ -169,7 +169,6 @@ fun TaskListDetail(
             // FIXME tweak colors, elevation, etc.
             TopAppBar(
                 title = {
-                    // FIXME title not updated on rename action
                     Text(text = taskList.title, style = MaterialTheme.typography.headlineSmall)
                 },
                 actions = {
@@ -201,7 +200,6 @@ fun TaskListDetail(
             }
         }
     ) { innerPadding ->
-        // FIXME tasks not updated on delete action
         Box(Modifier.padding(innerPadding)) {
             if (taskList.isEmpty) {
                 // TODO SVG undraw.co illustration `files/undraw_to_do_list_re_9nt7.svg`

--- a/tasks-app-shared/src/jvmMain/kotlin/net/opatry/tasks/app/ui/screen/taskListScreenJvm.kt
+++ b/tasks-app-shared/src/jvmMain/kotlin/net/opatry/tasks/app/ui/screen/taskListScreenJvm.kt
@@ -38,7 +38,6 @@ import net.opatry.tasks.app.ui.component.NoTaskListEmptyState
 import net.opatry.tasks.app.ui.component.NoTaskListSelectedEmptyState
 import net.opatry.tasks.app.ui.component.TaskListDetail
 import net.opatry.tasks.app.ui.component.TaskListsColumn
-import net.opatry.tasks.app.ui.model.TaskListUIModel
 import net.opatry.tasks.resources.Res
 import net.opatry.tasks.resources.default_task_list_title
 import org.jetbrains.compose.resources.stringResource
@@ -47,7 +46,9 @@ import org.jetbrains.compose.resources.stringResource
 actual fun TaskListsMasterDetail(viewModel: TaskListsViewModel) {
     val taskLists by viewModel.taskLists.collectAsState(emptyList())
 
-    var currentTaskList by remember { mutableStateOf<TaskListUIModel?>(null) }
+    // Store the list id, and not the list object to prevent keeping
+    // a stale object when data changes.
+    var currentTaskListId by remember { mutableStateOf<Long?>(null) }
 
     Row(Modifier.fillMaxWidth()) {
         if (taskLists.isEmpty()) {
@@ -60,9 +61,9 @@ actual fun TaskListsMasterDetail(viewModel: TaskListsViewModel) {
             Box(Modifier.weight(.3f)) {
                 TaskListsColumn(
                     taskLists,
-                    selectedItem = currentTaskList,
+                    selectedItem = taskLists.find { it.id == currentTaskListId },
                     onItemClick = { taskList ->
-                        currentTaskList = taskList
+                        currentTaskListId = taskList.id
                     }
                 )
             }
@@ -71,9 +72,9 @@ actual fun TaskListsMasterDetail(viewModel: TaskListsViewModel) {
         }
 
         Box(Modifier.weight(.7f)) {
-            currentTaskList?.let { taskList ->
+            taskLists.find { it.id == currentTaskListId }?.let { taskList ->
                 TaskListDetail(viewModel, taskList) { targetedTaskList ->
-                    currentTaskList = targetedTaskList
+                    currentTaskListId = targetedTaskList?.id
                 }
             } ?: run {
                 NoTaskListSelectedEmptyState()


### PR DESCRIPTION
### Description
The `TaskListUIModel` being stored in navigation was keeping a stale data and preventing recomposition with up to date data model.
Relying on list id allows requesting up to date data when needed.
