### PR TITLE
Add task list button

### DIFF
--- a/tasks-app-shared/src/androidMain/kotlin/net/opatry/tasks/app/ui/screen/taskListScreenAndroid.kt
+++ b/tasks-app-shared/src/androidMain/kotlin/net/opatry/tasks/app/ui/screen/taskListScreenAndroid.kt
@@ -45,7 +45,10 @@ import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
-actual fun TaskListsMasterDetail(viewModel: TaskListsViewModel) {
+actual fun TaskListsMasterDetail(
+    viewModel: TaskListsViewModel,
+    onNewTaskList: (String) -> Unit
+) {
     val taskLists by viewModel.taskLists.collectAsState(emptyList())
 
     // need to store a saveable (Serializable/Parcelable) object
@@ -63,16 +66,16 @@ actual fun TaskListsMasterDetail(viewModel: TaskListsViewModel) {
         listPane = {
             AnimatedPane {
                 if (taskLists.isEmpty()) {
-                    // TODO dialog to ask for the new task list name
                     val newTaskListName = stringResource(Res.string.default_task_list_title)
                     NoTaskListEmptyState {
-                        viewModel.createTaskList(newTaskListName)
+                        onNewTaskList(newTaskListName)
                     }
                 } else {
                     Row {
                         TaskListsColumn(
                             taskLists,
                             selectedItem = taskLists.find { it.id == navigator.currentDestination?.content },
+                            onNewTaskList = { onNewTaskList("") },
                             onItemClick = { taskList ->
                                 navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, taskList.id)
                             }

--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/TasksApp.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/TasksApp.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.dp
+import net.opatry.tasks.app.ui.component.EditTextDialog
 import net.opatry.tasks.app.ui.component.MissingScreen
 import net.opatry.tasks.app.ui.component.ProfileIcon
 import net.opatry.tasks.app.ui.screen.TaskListsMasterDetail
@@ -87,6 +88,9 @@ fun TasksApp(userViewModel: UserViewModel, tasksViewModel: TaskListsViewModel) {
     LaunchedEffect(isFocused, isSigned) {
         tasksViewModel.enableAutoRefresh(isFocused && isSigned)
     }
+
+    var newTaskListDefaultTitle by remember { mutableStateOf("") }
+    var showNewTaskListDialog by remember { mutableStateOf(false) }
 
     NavigationSuiteScaffold(navigationSuiteItems = {
         // Only if expanded state
@@ -134,7 +138,24 @@ fun TasksApp(userViewModel: UserViewModel, tasksViewModel: TaskListsViewModel) {
                         }
                     }
 
-                    TaskListsMasterDetail(tasksViewModel)
+                    TaskListsMasterDetail(tasksViewModel) { title ->
+                        newTaskListDefaultTitle = title
+                        showNewTaskListDialog = true
+                    }
+
+                    if (showNewTaskListDialog) {
+                        EditTextDialog(
+                            onDismissRequest = { showNewTaskListDialog = false },
+                            validateLabel = "Create",
+                            onValidate = { title ->
+                                showNewTaskListDialog = false
+                                tasksViewModel.createTaskList(title)
+                            },
+                            dialogTitle = "New task list",
+                            initialText = newTaskListDefaultTitle,
+                            allowBlank = false
+                        )
+                    }
                 }
 
                 AppTasksScreen.Calendar -> MissingScreen(stringResource(AppTasksScreen.Calendar.labelRes), LucideIcons.Calendar)

--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/component/EditTextDialog.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/component/EditTextDialog.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.tasks.app.ui.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialogDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+
+@Composable
+fun EditTextDialog(
+    onDismissRequest: () -> Unit,
+    validateLabel: String,
+    onValidate: (String) -> Unit,
+    dialogTitle: String? = null,
+    initialText: String = "",
+    allowBlank: Boolean = true,
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false)
+    ) {
+        var newTitle by remember { mutableStateOf(initialText) }
+        val hasError by remember(newTitle, allowBlank) {
+            derivedStateOf {
+                !allowBlank && newTitle.isBlank()
+            }
+        }
+
+        Surface(
+            shape = MaterialTheme.shapes.large,
+            tonalElevation = AlertDialogDefaults.TonalElevation
+        ) {
+            Column(Modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                if (dialogTitle != null) {
+                    Text(dialogTitle, style = MaterialTheme.typography.titleLarge)
+                }
+                OutlinedTextField(
+                    newTitle,
+                    onValueChange = { newTitle = it },
+                    maxLines = 1,
+                    supportingText = if (allowBlank) null else {
+                        {
+                            AnimatedVisibility(visible = hasError) {
+                                Text("Text cannot be empty")
+                            }
+                        }
+                    },
+                    isError = hasError,
+                )
+                Row(
+                    Modifier.align(Alignment.End),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    TextButton(onClick = onDismissRequest) {
+                        Text("Cancel")
+                    }
+                    Button(
+                        onClick = { onValidate(newTitle) },
+                        enabled = allowBlank || !hasError
+                    ) {
+                        Text(validateLabel)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/component/taskListsUI.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/component/taskListsUI.kt
@@ -22,18 +22,28 @@
 
 package net.opatry.tasks.app.ui.component
 
+import CircleFadingPlus
+import LucideIcons
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -44,16 +54,39 @@ import net.opatry.tasks.app.ui.tooling.TaskfolioPreview
 import net.opatry.tasks.app.ui.tooling.TaskfolioThemedPreview
 
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun TaskListsColumn(
     taskLists: List<TaskListUIModel>,
     selectedItem: TaskListUIModel? = null,
+    onNewTaskList: () -> Unit,
     onItemClick: (TaskListUIModel) -> Unit
 ) {
-    LazyColumn(contentPadding = PaddingValues(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    val listState = rememberLazyListState()
+    LazyColumn(state = listState, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        stickyHeader {
+            Box(
+                Modifier
+                    .background(MaterialTheme.colorScheme.background)
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp)
+            ) {
+                // TODO could be a "in-place" replace with a text field (no border)
+                TextButton(
+                    onClick = onNewTaskList,
+                ) {
+                    RowWithIcon("Add task list…", LucideIcons.CircleFadingPlus)
+                }
+            }
+
+            AnimatedVisibility(listState.firstVisibleItemScrollOffset > 0) {
+                HorizontalDivider()
+            }
+        }
         items(taskLists) { taskList ->
             TaskListRow(
                 taskList,
+                Modifier.padding(horizontal = 8.dp),
                 isSelected = taskList.id == selectedItem?.id,
                 onClick = { onItemClick(taskList) }
             )
@@ -64,6 +97,7 @@ fun TaskListsColumn(
 @Composable
 fun TaskListRow(
     taskList: TaskListUIModel,
+    modifier: Modifier = Modifier,
     isSelected: Boolean = false,
     onClick: () -> Unit
 ) {
@@ -72,7 +106,7 @@ fun TaskListRow(
         else -> Color.Transparent
     }
 
-    Card(colors = CardDefaults.outlinedCardColors(), onClick = onClick) {
+    Card(onClick = onClick, modifier = modifier, colors = CardDefaults.outlinedCardColors()) {
         ListItem(
             headlineContent = {
                 Text(taskList.title, overflow = TextOverflow.Ellipsis, maxLines = 1)
@@ -96,8 +130,8 @@ private fun TaskListRowScaffold(
             "TODO DATE",
             tasks = emptyList(),
         ),
-        isSelected,
-        {}
+        isSelected = isSelected,
+        onClick = {}
     )
 }
 

--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/component/tasksUI.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/component/tasksUI.kt
@@ -52,7 +52,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.DatePicker
@@ -74,7 +73,6 @@ import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -95,8 +93,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
@@ -252,55 +248,17 @@ fun TaskListDetail(
     }
 
     if (showRenameTaskListDialog) {
-        Dialog(
+        EditTextDialog(
             onDismissRequest = { showRenameTaskListDialog = false },
-            properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false)
-        ) {
-            var newTitle by remember { mutableStateOf(taskList.title) }
-            val hasError by remember {
-                derivedStateOf {
-                    newTitle.isBlank()
-                }
-            }
-
-            Surface(
-                shape = MaterialTheme.shapes.large,
-                tonalElevation = AlertDialogDefaults.TonalElevation
-            ) {
-                Column(Modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                    Text("Rename list", style = MaterialTheme.typography.titleLarge)
-                    OutlinedTextField(
-                        newTitle,
-                        onValueChange = { newTitle = it },
-                        maxLines = 1,
-                        supportingText = {
-                            AnimatedVisibility(visible = hasError) {
-                                Text("Title cannot be empty")
-                            }
-                        },
-                        isError = hasError,
-                    )
-                    Row(
-                        Modifier.align(Alignment.End),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        TextButton(onClick = { showRenameTaskListDialog = false }) {
-                            Text("Cancel")
-                        }
-                        Button(
-                            onClick = {
-                                showRenameTaskListDialog = false
-                                viewModel.renameTaskList(taskList, newTitle)
-                            },
-                            enabled = !hasError
-                        ) {
-                            Text("Rename")
-                        }
-                    }
-                }
-            }
-        }
+            onValidate = { newTitle ->
+                showRenameTaskListDialog = false
+                viewModel.renameTaskList(taskList, newTitle)
+            },
+            validateLabel = "Rename",
+            dialogTitle = "Rename list",
+            initialText = taskList.title,
+            allowBlank = false,
+        )
     }
 
     if (showClearTaskListCompletedTasksDialog) {

--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/component/tasksUI.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/component/tasksUI.kt
@@ -28,7 +28,6 @@ import ChevronDown
 import ChevronRight
 import Circle
 import CircleCheckBig
-import CircleFadingPlus
 import CircleOff
 import EllipsisVertical
 import LayoutList
@@ -61,7 +60,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -197,13 +195,7 @@ fun TaskListDetail(
             }
         }
     ) { innerPadding ->
-        Column(Modifier.padding(innerPadding)) {
-            TextButton(onClick = { showNewTaskSheet = true }) {
-                RowWithIcon("Add task", LucideIcons.CircleFadingPlus)
-            }
-
-            HorizontalDivider()
-
+        Box(Modifier.padding(innerPadding)) {
             if (taskList.isEmpty) {
                 // TODO SVG undraw.co illustration `files/undraw_to_do_list_re_9nt7.svg`
                 EmptyState(

--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/screen/taskListScreen.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/screen/taskListScreen.kt
@@ -26,4 +26,7 @@ import androidx.compose.runtime.Composable
 import net.opatry.tasks.app.ui.TaskListsViewModel
 
 @Composable
-expect fun TaskListsMasterDetail(viewModel: TaskListsViewModel)
+expect fun TaskListsMasterDetail(
+    viewModel: TaskListsViewModel,
+    onNewTaskList: (String) -> Unit
+)

--- a/tasks-app-shared/src/jvmMain/kotlin/net/opatry/tasks/app/ui/screen/taskListScreenJvm.kt
+++ b/tasks-app-shared/src/jvmMain/kotlin/net/opatry/tasks/app/ui/screen/taskListScreenJvm.kt
@@ -43,7 +43,10 @@ import net.opatry.tasks.resources.default_task_list_title
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
-actual fun TaskListsMasterDetail(viewModel: TaskListsViewModel) {
+actual fun TaskListsMasterDetail(
+    viewModel: TaskListsViewModel,
+    onNewTaskList: (String) -> Unit
+) {
     val taskLists by viewModel.taskLists.collectAsState(emptyList())
 
     // Store the list id, and not the list object to prevent keeping
@@ -52,16 +55,16 @@ actual fun TaskListsMasterDetail(viewModel: TaskListsViewModel) {
 
     Row(Modifier.fillMaxWidth()) {
         if (taskLists.isEmpty()) {
-            // TODO dialog to ask for the new task list name
             val newTaskListName = stringResource(Res.string.default_task_list_title)
             NoTaskListEmptyState {
-                viewModel.createTaskList(newTaskListName)
+                onNewTaskList(newTaskListName)
             }
         } else {
             Box(Modifier.weight(.3f)) {
                 TaskListsColumn(
                     taskLists,
                     selectedItem = taskLists.find { it.id == currentTaskListId },
+                    onNewTaskList = { onNewTaskList("") },
                     onItemClick = { taskList ->
                         currentTaskListId = taskList.id
                     }


### PR DESCRIPTION
### Description
Original UI was made as close as possible to Google Tasks web UI.
In parallel, the will to stick to MD3 & FAB made a double "Add task" button in the detail pane which was useless.
Also, the task list is presented with a "master/detail" flow in mind, not as presented in Google Tasks web UI or Android native app (which seems irrelevant).

With this work, the "Add task" button at top of the task list is removed but the same concept is reused in the list of task list. This is more than welcome, there wasn't ways to add new task list so far.

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
