### PR TITLE
Speed up CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,11 @@ jobs:
       with:
         add-job-summary-as-pr-comment: on-failure
 
+    - name: 🔓 Decrypt secrets
+      env:
+        PLAYSTORE_SECRET_PASSPHRASE: ${{ secrets.PLAYSTORE_SECRET_PASSPHRASE }}
+      run: ./_ci/decrypt_secrets.sh
+
     - name: 🔨 Build Desktop App 🖥️
       run: ./gradlew --no-daemon :tasks-app-desktop:assemble
 
@@ -40,15 +45,22 @@ jobs:
         KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
         KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
       run: |
-            ./_ci/decrypt_secrets.sh
             ./gradlew --no-daemon :tasks-app-android:assembleStoreRelease \
               -Pci=true \
               -Pplaystore.keystore.file="${PWD}/_ci/tasksApp.keystore" \
               -Pplaystore.keystore.password="${KEYSTORE_PASSWORD}" \
               -Pplaystore.keystore.key_password="${KEYSTORE_KEY_PASSWORD}"
 
+    # `test` to trigger as much Jvm tests as possible
+    # `:tasks-app-android:testStoreReleaseUnitTest` to restrict to only specific flavor(store)+variant(release) for `:tasks-app-android` module.
+    # `-x :tasks-app-android:test` to remove all tests from `:tasks-app-android` module not being covered by `:tasks-app-android:testStoreReleaseUnitTest`.
+    # `-x testDebugUnitTest` to avoid triggering tests both in debug & release build.
+    # `-x :tasks-app-android:build` to avoid triggering useless build tasks (typically for unused flavors).
+    #      Only rely on dependencies of `:tasks-app-android:testStoreReleaseUnitTest`.
     - name: ✅ Test
-      run: ./gradlew --no-daemon test
+      run: |
+            ./gradlew --no-daemon test :tasks-app-android:testStoreReleaseUnitTest \
+            -x :tasks-app-android:test -x testDebugUnitTest -x :tasks-app-android:build
 
     - name: 🗒️ Publish Test Reports
       uses: mikepenz/action-junit-report@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
       with:
         add-job-summary-as-pr-comment: on-failure
 
+    - name: 🔨 Build Desktop App 🖥️
+      run: ./gradlew --no-daemon :tasks-app-desktop:assemble
+
     - name: 🔨 Build Android App 📱
       env:
         PLAYSTORE_SECRET_PASSPHRASE: ${{ secrets.PLAYSTORE_SECRET_PASSPHRASE }}
@@ -43,9 +46,6 @@ jobs:
               -Pplaystore.keystore.file="${PWD}/_ci/tasksApp.keystore" \
               -Pplaystore.keystore.password="${KEYSTORE_PASSWORD}" \
               -Pplaystore.keystore.key_password="${KEYSTORE_KEY_PASSWORD}"
-
-    - name: 🔨 Build Desktop App 🖥️
-      run: ./gradlew --no-daemon :tasks-app-desktop:assemble
 
     - name: ✅ Test
       run: ./gradlew --no-daemon test

--- a/.idea/scopes/lucide_icons.xml
+++ b/.idea/scopes/lucide_icons.xml
@@ -1,3 +1,3 @@
 <component name="DependencyValidationManager">
-  <scope name="lucide-icons" pattern="file[google-tasks-kmp.lucide-icons*]:*//*" />
+  <scope name="lucide-icons" pattern="file[taskfolio.lucide-icons*]:*//*" />
 </component>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,7 +45,7 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "google-tasks-kmp"
+rootProject.name = "Taskfolio"
 
 include(":google:oauth")
 include(":google:tasks")


### PR DESCRIPTION
### Description
- Build Desktop app before Android
  - There is less to build, if a shared error exists, chances are it's spotted more quickly
- Finer test task selection to dismiss time consuming Android flavor specific tasks
  - Several tasks were executed for nothing (release vs debug build type, `dev` flavor…)


| # | Before | After  |
| :-: | ------: | ------: |
| 1 | Android 1'33" | Desktop 35" |
| 2 | Desktop 45" | Android 1'12" |
| 3 | Test 46" | Test 15" |
| Σ | Total 174" | Total 132" |

📉 ~25% build time improvement

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
