### PR TITLE
Use `secondaryContainer` color for task list card selection

### DIFF
--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/component/taskListsUI.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/component/taskListsUI.kt
@@ -36,17 +36,17 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import net.opatry.tasks.app.ui.model.TaskListUIModel
@@ -102,11 +102,14 @@ fun TaskListRow(
     onClick: () -> Unit
 ) {
     val cellBackground = when {
-        isSelected -> LocalContentColor.current.copy(alpha = .05f)
-        else -> Color.Transparent
+        isSelected -> MaterialTheme.colorScheme.secondaryContainer.copy(alpha = .3f)
+        else -> Color.Unspecified
     }
 
-    Card(onClick = onClick, modifier = modifier, colors = CardDefaults.outlinedCardColors()) {
+    Card(
+        onClick = onClick,
+        modifier = modifier.semantics { selected = isSelected },
+    ) {
         ListItem(
             headlineContent = {
                 Text(taskList.title, overflow = TextOverflow.Ellipsis, maxLines = 1)


### PR DESCRIPTION
### Description
Feels more relevant to use a container color for such a case.
Also, it's more enjoyable to have a (discrete) color here

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
