### PR TITLE
Fix Coil3 with Ktor3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ androidx-compose-m3-adaptive-layout = { module = "androidx.compose.material3.ada
 androidx-compose-m3-adaptive-navigation = { module = "androidx.compose.material3.adaptive:adaptive-navigation", version = "1.0.0" }
 
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
-coil-network = { module = "io.coil-kt.coil3:coil-network-ktor2", version.ref = "coil" }
+coil-network = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.7.0" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.9.2" }

--- a/tasks-app-android/src/main/assets/licenses_android.json
+++ b/tasks-app-android/src/main/assets/licenses_android.json
@@ -1877,7 +1877,7 @@
             ]
         },
         {
-            "uniqueId": "io.coil-kt.coil3:coil-network-ktor2-android",
+            "uniqueId": "io.coil-kt.coil3:coil-network-ktor3-android",
             "developers": [
                 {
                     "name": "Coil Contributors"
@@ -1885,7 +1885,7 @@
             ],
             "artifactVersion": "3.0.0-alpha10",
             "description": "An image loading library for Android and Compose Multiplatform.",
-            "name": "coil-network-ktor2",
+            "name": "coil-network-ktor3",
             "licenses": [
                 "Apache-2.0"
             ]

--- a/tasks-app-desktop/src/main/resources/licenses_desktop.json
+++ b/tasks-app-desktop/src/main/resources/licenses_desktop.json
@@ -333,7 +333,7 @@
             ],
             "artifactVersion": "3.0.0-alpha10",
             "description": "An image loading library for Android and Compose Multiplatform.",
-            "name": "coil-network-ktor2",
+            "name": "coil-network-ktor3",
             "licenses": [
                 "Apache-2.0"
             ]

--- a/tasks-app-shared/src/jvmMain/kotlin/net/opatry/tasks/app/di/platformModule.jvm.kt
+++ b/tasks-app-shared/src/jvmMain/kotlin/net/opatry/tasks/app/di/platformModule.jvm.kt
@@ -34,7 +34,12 @@ import java.io.File
 actual fun platformModule(): Module = module {
     single(named("app_root_dir")) {
         val userHome = File(System.getProperty("user.home"))
-        File(userHome, ".tasksApp")
+        val legacyRootDir = File(userHome, ".tasksApp")
+        val rootDir = File(userHome, ".taskfolio")
+        if (legacyRootDir.isDirectory && !rootDir.exists()) {
+            legacyRootDir.renameTo(rootDir)
+        }
+        rootDir
     }
 
     single {


### PR DESCRIPTION
### Description
When updated to Ktor3, the Coil3 network module was kept relying on Ktor2, which led to `NoClassDefFoundError` error.

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
