### PR TITLE
Fix `DateRange` used directly as key in `stickyHeader` (fixes #64)

### DIFF
--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/TaskListsViewModel.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/TaskListsViewModel.kt
@@ -59,7 +59,7 @@ private fun TaskListDataModel.asTaskListUIModel(): TaskListUIModel {
             .groupBy { task ->
                 when (task.dateRange) {
                     // merge all overdue tasks to the same range
-                    is DateRange.Overdue -> DateRange.Overdue(LocalDate.fromEpochDays(-1), 1)
+                    is DateRange.Overdue -> DateRange.Overdue(LocalDate.fromEpochDays(0), -1)
                     else -> task.dateRange
                 }
             }

--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/screen/tasksPane.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/screen/tasksPane.kt
@@ -606,7 +606,7 @@ fun TasksColumn(
 
         taskList.remainingTasks.forEach { (dateRange, tasks) ->
             if (dateRange != null) {
-                stickyHeader(key = dateRange) {
+                stickyHeader(key = dateRange.key) {
                     Box(
                         Modifier
                             .fillMaxWidth()
@@ -689,8 +689,16 @@ fun TasksColumn(
     }
 }
 
+private val DateRange.key: String
+    get() = when (this) {
+        is DateRange.Overdue -> "overdue${numberOfDays}"
+        is DateRange.Today -> "today"
+        is DateRange.Later -> "later${numberOfDays}"
+        DateRange.None -> "none"
+    }
+
 @Composable
-fun DateRange?.toColor(): Color = when (this) {
+private fun DateRange?.toColor(): Color = when (this) {
     is DateRange.Overdue -> MaterialTheme.colorScheme.error
     is DateRange.Today -> MaterialTheme.colorScheme.primary
     is DateRange.Later,
@@ -699,7 +707,7 @@ fun DateRange?.toColor(): Color = when (this) {
 }
 
 @Composable
-fun DateRange.toLabel(sectionLabel: Boolean = false): String = when (this) {
+private fun DateRange.toLabel(sectionLabel: Boolean = false): String = when (this) {
     is DateRange.Overdue -> {
         val numberOfDays = abs(numberOfDays)
         when {


### PR DESCRIPTION
### Description
`DateRange` can't be stored in a `Bundle` on Android, need to use another type compatible.

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
