### PR TITLE
Fix missing "All tasks complete" empty state when sorted manually (fixes #63)

### DIFF
--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/model/TaskListUIModel.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/model/TaskListUIModel.kt
@@ -34,12 +34,14 @@ data class TaskListUIModel(
     val sorting: TaskListSorting = TaskListSorting.Manual,
 ) {
     fun containsTask(task: TaskUIModel, includeCompleted: Boolean = false): Boolean {
-        return remainingTasks.values.flatten().contains(task)
+        return allRemainingTasks.contains(task)
                 || (includeCompleted && completedTasks.contains(task))
     }
 
-    val isEmpty: Boolean = remainingTasks.isEmpty() && completedTasks.isEmpty()
+    val allRemainingTasks: List<TaskUIModel>
+        get() = remainingTasks.values.flatten()
+    val isEmpty: Boolean = allRemainingTasks.isEmpty() && completedTasks.isEmpty()
     val hasCompletedTasks: Boolean = completedTasks.isNotEmpty()
-    val isEmptyRemainingTasksVisible: Boolean = remainingTasks.isEmpty() && hasCompletedTasks
+    val isEmptyRemainingTasksVisible: Boolean = allRemainingTasks.isEmpty() && hasCompletedTasks
     val canDelete: Boolean = true // FIXME default list can't be deleted, how to know it?
 }


### PR DESCRIPTION
### Description
The `Map<DateRange?, List<TaskUIModel>>` wasn't appropriate to check for empty list.
Need to reason about `values.flatten()` to be accurate.

All completed tasks are currently represented by `mapOf(null to emptyList())` which isn't empty.

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
