### PR TITLE
Fix local only tasks sync

### DIFF
--- a/google/tasks/src/commonMain/kotlin/net/opatry/google/tasks/model/Task.kt
+++ b/google/tasks/src/commonMain/kotlin/net/opatry/google/tasks/model/Task.kt
@@ -116,3 +116,25 @@ data class Task(
         val link: String
     )
 }
+
+/**
+ * Factory function to create a new [TaskList] exposing only relevant parameters.
+ *
+ * @property title Title of the task. Maximum length allowed: 1024 characters.
+ * @property notes Notes describing the task. Tasks assigned from Google Docs cannot have notes. Optional. Maximum length allowed: 8192 characters.
+ * @property status Status of the task. This is either [Status.NeedsAction] or [Status.Completed].
+ * @property dueDate Due date of the task (as a RFC 3339 timestamp). Optional. The due date only records date information; the time portion of the timestamp is discarded when setting the due date. It isn't possible to read or write the time that a task is due via the API.
+ * @property completedDate Completion date of the task (as a RFC 3339 timestamp). This field is omitted if the task has not been completed.
+ */
+fun Task(
+    title: String,
+    notes: String? = null,
+    status: Status = Status.NeedsAction,
+    dueDate: Instant? = null,
+    completedDate: Instant? = null
+): Task {
+    require(title.length <= 1024) { "Title length must be at most 1024 characters" }
+    require(notes == null || notes.length <= 8192) { "Notes length must be at most 8192 characters" }
+    // need to artificially define an extra parameter to call data class ctor instead of recursive call
+    return Task(id = "", title = title, notes = notes, status = status, dueDate = dueDate, completedDate = completedDate)
+}

--- a/google/tasks/src/commonMain/kotlin/net/opatry/google/tasks/model/TaskList.kt
+++ b/google/tasks/src/commonMain/kotlin/net/opatry/google/tasks/model/TaskList.kt
@@ -53,3 +53,14 @@ data class TaskList(
     @SerialName("selfLink")
     val selfLink: String = "",
 )
+
+/**
+ * Factory function to create a new [TaskList] exposing only relevant parameters.
+ *
+ * @param title Title of the task list. Maximum length allowed: 1024 characters.
+ */
+fun TaskList(title: String): TaskList {
+    require(title.length <= 1024) { "Title length must be at most 1024 characters" }
+    // need to artificially define an extra parameter to call data class ctor instead of recursive call
+    return TaskList(id = "", title = title)
+}

--- a/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/TaskDao.kt
+++ b/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/TaskDao.kt
@@ -32,8 +32,11 @@ import net.opatry.tasks.data.entity.TaskEntity
 
 @Dao
 interface TaskDao {
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insert(item: TaskEntity): Long
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(item: TaskEntity): Long
 
     @Query("SELECT * FROM task WHERE remote_id = :remoteId")
     suspend fun getByRemoteId(remoteId: String): TaskEntity?
@@ -41,8 +44,8 @@ interface TaskDao {
     @Query("SELECT * FROM task")
     fun getAllAsFlow(): Flow<List<TaskEntity>>
 
-    @Query("SELECT * FROM task WHERE remote_id IS NULL")
-    suspend fun getLocalOnlyTasks(): List<TaskEntity>
+    @Query("SELECT * FROM task WHERE parent_list_local_id = :taskListLocalId AND remote_id IS NULL")
+    suspend fun getLocalOnlyTasks(taskListLocalId: Long): List<TaskEntity>
 
     // FIXME should be a pending deletion "flag" until sync is done
     @Query("DELETE FROM task WHERE local_id = :id")

--- a/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/TaskListDao.kt
+++ b/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/TaskListDao.kt
@@ -32,8 +32,11 @@ import net.opatry.tasks.data.entity.TaskListEntity
 
 @Dao
 interface TaskListDao {
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insert(item: TaskListEntity): Long
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(item: TaskListEntity): Long
 
     // FIXME should be a pending deletion "flag" until sync is done
     @Query("DELETE FROM task_list WHERE local_id = :id")

--- a/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/TaskRepository.kt
+++ b/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/TaskRepository.kt
@@ -118,6 +118,9 @@ private fun TaskEntity.asTask(): Task {
         updatedDate = lastUpdateDate,
         status = if (isCompleted) Task.Status.Completed else Task.Status.NeedsAction,
         completedDate = completionDate,
+        // doc says it's a read only field, but status is not hidden when syncing local only completed tasks
+        // forcing the hidden status works and makes everything more consistent (position following 099999... pattern, hidden status)
+        isHidden = isCompleted,
         position = position,
     )
 }

--- a/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/UserDao.kt
+++ b/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/UserDao.kt
@@ -32,8 +32,11 @@ import net.opatry.tasks.data.entity.UserEntity
 
 @Dao
 interface UserDao {
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insert(user: UserEntity): Long
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(user: UserEntity): Long
 
     @Query("SELECT * FROM user WHERE remote_id = :remoteId")
     suspend fun getByRemoteId(remoteId: String): UserEntity?
@@ -61,6 +64,6 @@ interface UserDao {
     @Transaction
     suspend fun setSignedInUser(userEntity: UserEntity) {
         clearAllSignedInStatus()
-        insert(userEntity.copy(isSignedIn = true))
+        upsert(userEntity.copy(isSignedIn = true))
     }
 }


### PR DESCRIPTION
### Description
There were several issues:
- local list id not properly managed to link to remote id (leading to task being moved in default list)
- notes, due date and other fields weren't transfered from local to remote task
- no proper dispatch of IO thread for API calls
- syncing local only completed lead to weird remote task status (completed but not hidden, `position` not following the `099999` pattern
- local only task processing was also made several times not taking into account the associated task list

Took the opportunity of these change to distinguish `insert` from `update` (using `upsert` pattern in such a case).
Also added `TaskList` & `Task` factories avoiding the use of read only/output only fields of the API data class bindings.

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
