### PR TITLE
Improve sync test linked to network availability & fix `Post` request response

### DIFF
--- a/tasks-app-shared/src/commonTest/kotlin/net/opatry/tasks/data/util/taskResponses.kt
+++ b/tasks-app-shared/src/commonTest/kotlin/net/opatry/tasks/data/util/taskResponses.kt
@@ -55,6 +55,14 @@ fun MockRequestHandleScope.respondWithTaskLists(vararg idToTitles: Pair<String, 
     )
 }
 
+fun MockRequestHandleScope.respondWithTaskList(id: String, title: String): HttpResponseData {
+    return respond(
+        content = Json.encodeToString(TaskList(id = id, title = title)),
+        status = HttpStatusCode.OK,
+        headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+    )
+}
+
 fun MockRequestHandleScope.respondWithTasks(vararg idToTitles: Pair<String, String>): HttpResponseData {
     val tasks = idToTitles.map { Task(id = it.first, title = it.second) }
     val tasksResponse = ResourceListResponse(


### PR DESCRIPTION
### Description
Relying on "request count" in test to determine which should be a "no network connection" or not wasn't ideal.
Making things explicit is better.
Also, the `Post` request was returning a response list but should have been a single `TaskList`.

Note: this is still a bit weird/fragile to rely on endpoint url & Http verb to determine the result.
Typically, `Get` task list here always return empty, but wouldn't after second `sync()` call.

This is left for later if a better pattern emerges.

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
