### PR TITLE
Only display empty title error when user already entered content and then removed it

### DIFF
--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/component/EditTextDialog.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/component/EditTextDialog.kt
@@ -65,6 +65,8 @@ fun EditTextDialog(
         properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false)
     ) {
         var newTitle by remember { mutableStateOf(initialText) }
+        // avoid displaying an error message when user didn't even started to write content
+        var alreadyHadSomeContent by remember { mutableStateOf(initialText.isNotBlank()) }
         val hasError by remember(newTitle, allowBlank) {
             derivedStateOf {
                 !allowBlank && newTitle.isBlank()
@@ -81,17 +83,20 @@ fun EditTextDialog(
                 }
                 OutlinedTextField(
                     newTitle,
-                    onValueChange = { newTitle = it },
+                    onValueChange = {
+                        alreadyHadSomeContent = alreadyHadSomeContent || it.isNotBlank()
+                        newTitle = it
+                    },
                     label = { Text(stringResource(Res.string.edit_text_dialog_title)) },
                     maxLines = 1,
                     supportingText = if (allowBlank) null else {
                         {
-                            AnimatedVisibility(visible = hasError) {
+                            AnimatedVisibility(visible = hasError && alreadyHadSomeContent) {
                                 Text(stringResource(Res.string.edit_text_dialog_empty_title_error))
                             }
                         }
                     },
-                    isError = hasError,
+                    isError = hasError && alreadyHadSomeContent,
                 )
                 Row(
                     Modifier.align(Alignment.End),

--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/screen/tasksPane.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/screen/tasksPane.kt
@@ -410,9 +410,11 @@ fun TaskListDetail(
         ) {
             val sheetTitleRes = if (showEditTaskSheet) Res.string.task_editor_sheet_edit_title else Res.string.task_editor_sheet_new_title
             var newTitle by remember { mutableStateOf(task?.title ?: "") }
+            // avoid displaying an error message when user didn't even started to write content
+            var alreadyHadSomeContent by remember { mutableStateOf((task?.title ?: "").isNotBlank()) }
             val titleHasError by remember {
                 derivedStateOf {
-                    showEditTaskSheet && newTitle.isBlank()
+                    newTitle.isBlank()
                 }
             }
             var newNotes by remember { mutableStateOf(task?.notes ?: "") }
@@ -435,13 +437,16 @@ fun TaskListDetail(
 
                 OutlinedTextField(
                     newTitle,
-                    onValueChange = { newTitle = it },
+                    onValueChange = {
+                        alreadyHadSomeContent = alreadyHadSomeContent || it.isNotBlank()
+                        newTitle = it
+                    },
                     modifier = Modifier.fillMaxWidth(),
                     label = { Text(stringResource(Res.string.task_editor_sheet_title_field_label)) },
                     placeholder = { Text(stringResource(Res.string.task_editor_sheet_title_field_placeholder)) },
                     maxLines = 1,
                     supportingText = {
-                        AnimatedVisibility(visible = titleHasError) {
+                        AnimatedVisibility(visible = titleHasError && alreadyHadSomeContent) {
                             Text(stringResource(Res.string.task_editor_sheet_title_field_empty_error))
                         }
                     },
@@ -449,7 +454,7 @@ fun TaskListDetail(
                         keyboardType = KeyboardType.Text,
                         imeAction = ImeAction.Next,
                     ),
-                    isError = titleHasError,
+                    isError = titleHasError && alreadyHadSomeContent,
                 )
 
                 OutlinedTextField(


### PR DESCRIPTION
### Description
This avoids displaying error message right away when opening a title dialog for the first time

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
