### PR TITLE
Re-enable minify (R8) for Android

### DIFF
--- a/tasks-app-android/build.gradle.kts
+++ b/tasks-app-android/build.gradle.kts
@@ -55,12 +55,6 @@ android {
         generateLocaleConfig = true
     }
 
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-        }
-    }
-
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
@@ -118,8 +112,8 @@ android {
                 signingConfigs.getByName("store")
             }
 
-            isMinifyEnabled = false
-            isShrinkResources = false
+            isMinifyEnabled = true
+            isShrinkResources = true
         }
     }
 


### PR DESCRIPTION
Final Store release APK went from 17MB to 10MB.

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
