### PR TITLE
Update Compose navigation to 2.9.0-beta01 following Compose 1.8.0 release

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ compose-plugin = "1.8.0"
 compose-hot-reload-plugin = "1.0.0-alpha09"
 compose-ui-preview = "1.8.0"
 compose-m3-adaptive = "1.1.0"
+compose-lifecycle = "2.8.4"
+compose-navigation = "2.9.0-beta01"
 room = "2.7.1"
 sqlite = "2.5.0"
 koin = "4.0.4"
@@ -50,8 +52,9 @@ androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "
 androidx-sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite" }
 androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
 
-jetbrains-lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version = "2.8.4" }
-jetbrains-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version = "2.9.0-alpha16" }
+jetbrains-lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "compose-lifecycle" }
+jetbrains-lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "compose-lifecycle" }
+jetbrains-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "compose-navigation" }
 
 koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin" }
 koin-core = { module = "io.insert-koin:koin-core" }

--- a/tasks-app-android/src/main/assets/licenses_android.json
+++ b/tasks-app-android/src/main/assets/licenses_android.json
@@ -906,7 +906,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha12",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Lifecycle-Common",
             "name": "Lifecycle-Common",
             "licenses": [
@@ -923,7 +923,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha12",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Lifecycle-Common for Java 8 Language",
             "name": "Lifecycle-Common for Java 8",
             "licenses": [
@@ -940,7 +940,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha12",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Lifecycle LiveData Core",
             "name": "Lifecycle LiveData Core",
             "licenses": [
@@ -957,7 +957,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha12",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Kotlin extensions for 'livedata-core' artifact",
             "name": "LiveData Core Kotlin Extensions",
             "licenses": [
@@ -974,7 +974,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha12",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Lifecycle Process",
             "name": "Lifecycle Process",
             "licenses": [
@@ -991,7 +991,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha12",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Lifecycle Runtime",
             "name": "Lifecycle Runtime",
             "licenses": [
@@ -1008,7 +1008,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha12",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Compose integration with Lifecycle",
             "name": "Lifecycle Runtime Compose",
             "licenses": [
@@ -1025,7 +1025,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha12",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Kotlin extensions for 'lifecycle' artifact",
             "name": "Lifecycle Kotlin Extensions",
             "licenses": [
@@ -1042,7 +1042,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha12",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Lifecycle ViewModel",
             "name": "Lifecycle ViewModel",
             "licenses": [
@@ -1059,7 +1059,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha12",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Compose integration with Lifecycle ViewModel",
             "name": "Lifecycle ViewModel Compose",
             "licenses": [
@@ -1076,7 +1076,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha12",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Kotlin extensions for 'viewmodel' artifact",
             "name": "Lifecycle ViewModel Kotlin Extensions",
             "licenses": [
@@ -1093,7 +1093,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha12",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Lifecycle ViewModel",
             "name": "Lifecycle ViewModel with SavedState",
             "licenses": [
@@ -1124,7 +1124,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha08",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Navigation-Common",
             "name": "Navigation Common",
             "licenses": [
@@ -1141,7 +1141,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha08",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Compose integration with Navigation",
             "name": "Compose Navigation",
             "licenses": [
@@ -1158,7 +1158,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha08",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Navigation-Runtime",
             "name": "Navigation Runtime",
             "licenses": [
@@ -1240,9 +1240,26 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "1.3.0-alpha10",
+            "artifactVersion": "1.3.0-beta01",
             "description": "Android Lifecycle Saved State",
             "name": "Saved State",
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "organization": {
+                "name": "The Android Open Source Project"
+            }
+        },
+        {
+            "uniqueId": "androidx.savedstate:savedstate-compose",
+            "developers": [
+                {
+                    "name": "The Android Open Source Project"
+                }
+            ],
+            "artifactVersion": "1.3.0-beta01",
+            "description": "Compose integration with Saved State",
+            "name": "Saved State Compose",
             "licenses": [
                 "Apache-2.0"
             ],
@@ -1257,7 +1274,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "1.3.0-alpha10",
+            "artifactVersion": "1.3.0-beta01",
             "description": "Kotlin extensions for 'savedstate' artifact",
             "name": "SavedState Kotlin Extensions",
             "licenses": [
@@ -2225,7 +2242,7 @@
                     "name": "Compose Multiplatform Team"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha06",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Lifecycle-Common",
             "name": "Lifecycle-Common",
             "licenses": [
@@ -2239,7 +2256,7 @@
                     "name": "Compose Multiplatform Team"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha06",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Lifecycle Runtime",
             "name": "Lifecycle Runtime",
             "licenses": [
@@ -2253,7 +2270,7 @@
                     "name": "Compose Multiplatform Team"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha06",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Compose integration with Lifecycle",
             "name": "Lifecycle Runtime Compose",
             "licenses": [
@@ -2267,7 +2284,7 @@
                     "name": "Compose Multiplatform Team"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha06",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Lifecycle ViewModel",
             "name": "Lifecycle ViewModel",
             "licenses": [
@@ -2281,7 +2298,7 @@
                     "name": "Compose Multiplatform Team"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha06",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Compose integration with Lifecycle ViewModel",
             "name": "Lifecycle ViewModel Compose",
             "licenses": [
@@ -2295,7 +2312,7 @@
                     "name": "Compose Multiplatform Team"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha06",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Lifecycle ViewModel",
             "name": "Lifecycle ViewModel with SavedState",
             "licenses": [
@@ -2309,7 +2326,7 @@
                     "name": "Compose Multiplatform Team"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha16",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Navigation-Common",
             "name": "Navigation Common",
             "licenses": [
@@ -2323,7 +2340,7 @@
                     "name": "Compose Multiplatform Team"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha16",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Compose integration with Navigation",
             "name": "Compose Navigation",
             "licenses": [
@@ -2337,7 +2354,7 @@
                     "name": "Compose Multiplatform Team"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha16",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Navigation-Runtime",
             "name": "Navigation Runtime",
             "licenses": [
@@ -2351,9 +2368,23 @@
                     "name": "Compose Multiplatform Team"
                 }
             ],
-            "artifactVersion": "1.3.0-alpha06",
+            "artifactVersion": "1.3.0-beta01",
             "description": "Android Lifecycle Saved State",
             "name": "Saved State",
+            "licenses": [
+                "Apache-2.0"
+            ]
+        },
+        {
+            "uniqueId": "org.jetbrains.androidx.savedstate:savedstate-compose",
+            "developers": [
+                {
+                    "name": "Compose Multiplatform Team"
+                }
+            ],
+            "artifactVersion": "1.3.0-beta01",
+            "description": "Compose integration with Saved State",
+            "name": "Saved State Compose",
             "licenses": [
                 "Apache-2.0"
             ]

--- a/tasks-app-desktop/src/main/resources/licenses_desktop.json
+++ b/tasks-app-desktop/src/main/resources/licenses_desktop.json
@@ -72,7 +72,7 @@
                     "name": "The Android Open Source Project"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha12",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Lifecycle Runtime",
             "name": "Lifecycle Runtime",
             "licenses": [
@@ -92,6 +92,23 @@
             "artifactVersion": "2.8.5",
             "description": "Android Lifecycle ViewModel",
             "name": "Lifecycle ViewModel",
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "organization": {
+                "name": "The Android Open Source Project"
+            }
+        },
+        {
+            "uniqueId": "androidx.lifecycle:lifecycle-viewmodel-savedstate",
+            "developers": [
+                {
+                    "name": "The Android Open Source Project"
+                }
+            ],
+            "artifactVersion": "2.9.0-beta01",
+            "description": "Android Lifecycle ViewModel",
+            "name": "Lifecycle ViewModel with SavedState",
             "licenses": [
                 "Apache-2.0"
             ],
@@ -126,6 +143,23 @@
             "artifactVersion": "2.7.1",
             "description": "Android Room-Runtime",
             "name": "Room-Runtime",
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "organization": {
+                "name": "The Android Open Source Project"
+            }
+        },
+        {
+            "uniqueId": "androidx.savedstate:savedstate",
+            "developers": [
+                {
+                    "name": "The Android Open Source Project"
+                }
+            ],
+            "artifactVersion": "1.3.0-beta01",
+            "description": "Android Lifecycle Saved State",
+            "name": "Saved State",
             "licenses": [
                 "Apache-2.0"
             ],
@@ -704,7 +738,7 @@
                     "name": "Compose Multiplatform Team"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha06",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Lifecycle Runtime",
             "name": "Lifecycle Runtime",
             "licenses": [
@@ -718,7 +752,7 @@
                     "name": "Compose Multiplatform Team"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha06",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Compose integration with Lifecycle",
             "name": "Lifecycle Runtime Compose",
             "licenses": [
@@ -774,7 +808,7 @@
                     "name": "Compose Multiplatform Team"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha16",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Navigation-Common",
             "name": "Navigation Common",
             "licenses": [
@@ -788,7 +822,7 @@
                     "name": "Compose Multiplatform Team"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha16",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Compose integration with Navigation",
             "name": "Compose Navigation",
             "licenses": [
@@ -802,7 +836,7 @@
                     "name": "Compose Multiplatform Team"
                 }
             ],
-            "artifactVersion": "2.9.0-alpha16",
+            "artifactVersion": "2.9.0-beta01",
             "description": "Android Navigation-Runtime",
             "name": "Navigation Runtime",
             "licenses": [
@@ -819,6 +853,20 @@
             "artifactVersion": "1.2.2",
             "description": "Android Lifecycle Saved State",
             "name": "Saved State",
+            "licenses": [
+                "Apache-2.0"
+            ]
+        },
+        {
+            "uniqueId": "org.jetbrains.androidx.savedstate:savedstate-compose",
+            "developers": [
+                {
+                    "name": "Compose Multiplatform Team"
+                }
+            ],
+            "artifactVersion": "1.3.0-beta01",
+            "description": "Compose integration with Saved State",
+            "name": "Saved State Compose",
             "licenses": [
                 "Apache-2.0"
             ]

--- a/tasks-app-shared/build.gradle.kts
+++ b/tasks-app-shared/build.gradle.kts
@@ -93,6 +93,7 @@ kotlin {
             implementation(libs.compose.m3.adaptive.navigation)
             implementation(libs.bundles.coil)
 
+            implementation(libs.jetbrains.lifecycle.runtime.compose)
             implementation(libs.jetbrains.lifecycle.viewmodel.compose)
             implementation(libs.jetbrains.navigation.compose)
 


### PR DESCRIPTION
### Description
Had to introduce `lifecyle-runtime` to properly resolve `collectAsStateWithLifecycle` following the update of compose navigation 🤷‍♂️ 

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
