### PR TITLE
Enable Ktor `HttpCaching`

### DIFF
--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/di/networkModule.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/di/networkModule.kt
@@ -28,6 +28,7 @@ import io.ktor.client.plugins.CurlUserAgent
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
+import io.ktor.client.plugins.cache.HttpCache
 import io.ktor.client.plugins.compression.ContentEncoding
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
@@ -81,6 +82,7 @@ val networkModule = module {
                     }
                 }
             }
+            install(HttpCache)
             install(Auth) {
                 bearer {
                     // TODO handle 401 (clear storage)


### PR DESCRIPTION
When testing with 2 consecutive calls to https://httpbin.org/cache, I get 200 OK and 304 NOT MODIFIED as expected. That being said, when using Google Tasks API, I only get 200… maybe server doesn't provide Http Caching?

With httpbin requests:

```
REQUEST: https://httpbin.org/cache
METHOD: GET
COMMON HEADERS
-> Accept: application/json
-> Accept-Charset: UTF-8
-> Accept-Encoding: gzip
-> Authorization: Bearer xxxx
-> User-Agent: curl/7.61.0
CONTENT HEADERS
-> Content-Length: 0
RESPONSE: 200 OK
METHOD: GET
FROM: https://httpbin.org/cache
COMMON HEADERS
-> Access-Control-Allow-Credentials: true
-> Access-Control-Allow-Origin: *
-> Connection: keep-alive
-> Content-Length: 591
-> Content-Type: application/json
-> Date: Thu, 08 May 2025 18:58:23 GMT
-> ETag: 4e488dc9a19e48f884cfca5e77607599
-> Last-Modified: Thu, 08 May 2025 18:58:23 GMT
-> Server: gunicorn/19.9.0
=======================================================================================
REQUEST: https://httpbin.org/cache
METHOD: GET
COMMON HEADERS
-> Accept: application/json
-> Accept-Charset: UTF-8
-> Accept-Encoding: gzip
-> Authorization: Bearer xxxx
-> If-Modified-Since: Thu, 08 May 2025 18:58:23 GMT
-> If-None-Match: 4e488dc9a19e48f884cfca5e77607599
-> User-Agent: curl/7.61.0
CONTENT HEADERS
-> Content-Length: 0
RESPONSE: 304 NOT MODIFIED
METHOD: GET
FROM: https://httpbin.org/cache
COMMON HEADERS
-> Access-Control-Allow-Credentials: true
-> Access-Control-Allow-Origin: *
-> Connection: keep-alive
-> Date: Thu, 08 May 2025 18:58:26 GMT
-> Server: gunicorn/19.9.0
```

With Google Tasks requests:

```
REQUEST: https://tasks.googleapis.com/tasks/v1/users/@me/lists
METHOD: GET
COMMON HEADERS
-> Accept: application/json
-> Accept-Charset: UTF-8
-> Accept-Encoding: gzip
-> Authorization: Bearer xxxx
-> User-Agent: curl/7.61.0
CONTENT HEADERS
-> Content-Length: 0
RESPONSE: 200 OK
METHOD: GET
FROM: https://tasks.googleapis.com/tasks/v1/users/@me/lists
COMMON HEADERS
-> Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-> Content-Type: application/json; charset=UTF-8
-> Date: Thu, 08 May 2025 18:55:57 GMT
-> ETag: "jN-nxpZbjK0"
-> Server: ESF
-> Transfer-Encoding: chunked
-> Vary: Origin; X-Origin; Referer
-> X-Content-Type-Options: nosniff
-> X-Frame-Options: SAMEORIGIN
-> X-XSS-Protection: 0
-> x-l2-request-path: l2-managed-14
=======================================================================================
REQUEST: https://tasks.googleapis.com/tasks/v1/users/@me/lists
METHOD: GET
COMMON HEADERS
-> Accept: application/json
-> Accept-Charset: UTF-8
-> Accept-Encoding: gzip
-> Authorization: Bearer xxxx
-> If-None-Match: "jN-nxpZbjK0"
-> User-Agent: curl/7.61.0
CONTENT HEADERS
-> Content-Length: 0
RESPONSE: 200 OK
METHOD: GET
FROM: https://tasks.googleapis.com/tasks/v1/users/@me/lists
COMMON HEADERS
-> Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-> Content-Type: application/json; charset=UTF-8
-> Date: Thu, 08 May 2025 18:55:58 GMT
-> ETag: "jN-nxpZbjK0"
-> Server: ESF
-> Transfer-Encoding: chunked
-> Vary: Origin; X-Origin; Referer
-> X-Content-Type-Options: nosniff
-> X-Frame-Options: SAMEORIGIN
-> X-XSS-Protection: 0
-> x-l2-request-path: l2-managed-14
```

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
