### PR TITLE
Local task sorting à-la Google Tasks

### DIFF
--- a/tasks-core/build.gradle.kts
+++ b/tasks-core/build.gradle.kts
@@ -42,5 +42,9 @@ kotlin {
 
             implementation(libs.androidx.room.common)
         }
+
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
     }
 }

--- a/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/TaskDao.kt
+++ b/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/TaskDao.kt
@@ -41,10 +41,10 @@ interface TaskDao {
     @Query("SELECT * FROM task WHERE remote_id = :remoteId")
     suspend fun getByRemoteId(remoteId: String): TaskEntity?
 
-    @Query("SELECT * FROM task")
+    @Query("SELECT * FROM task ORDER BY position ASC")
     fun getAllAsFlow(): Flow<List<TaskEntity>>
 
-    @Query("SELECT * FROM task WHERE parent_list_local_id = :taskListLocalId AND remote_id IS NULL")
+    @Query("SELECT * FROM task WHERE parent_list_local_id = :taskListLocalId AND remote_id IS NULL ORDER BY position ASC")
     suspend fun getLocalOnlyTasks(taskListLocalId: Long): List<TaskEntity>
 
     // FIXME should be a pending deletion "flag" until sync is done
@@ -55,7 +55,7 @@ interface TaskDao {
     @Query("DELETE FROM task WHERE local_id IN (:ids)")
     suspend fun deleteTasks(ids: List<Long>)
 
-    @Query("SELECT * FROM task WHERE parent_list_local_id = :taskListLocalId AND is_completed = true")
+    @Query("SELECT * FROM task WHERE parent_list_local_id = :taskListLocalId AND is_completed = true ORDER BY position ASC")
     suspend fun getCompletedTasks(taskListLocalId: Long): List<TaskEntity>
 
     @Query("DELETE FROM task WHERE parent_list_local_id = :taskListId AND remote_id IS NOT NULL AND remote_id NOT IN (:validRemoteIds)")

--- a/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/TaskRepository.kt
+++ b/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/TaskRepository.kt
@@ -127,15 +127,15 @@ private fun TaskEntity.asTask(): Task {
 
 fun sortTasksManualOrdering(tasks: List<TaskEntity>): List<Pair<TaskEntity, Int>> {
     // Step 1: Create a map of tasks by their IDs for easy lookup
-    val taskMap = tasks.associateBy { it.remoteId ?: it.id.toString() }.toMutableMap() // FIXME local data only?
+    val taskMap = tasks.associateBy { it.remoteId ?: it.id.toString() }.toMutableMap()
 
     // Step 2: Build a tree structure with parent-child relationships
     val tree = mutableMapOf<String, MutableList<TaskEntity>>()
     tasks.forEach { task ->
-        val parentId = task.parentTaskRemoteId ?: task.parentTaskLocalId?.toString() // FIXME local data only?
+        val parentId = task.parentTaskRemoteId ?: task.parentTaskLocalId?.toString()
         if (parentId == null) {
             // Tasks with no parent go directly into the root of the tree
-            tree.getOrPut(task.remoteId ?: task.id.toString()) { mutableListOf() } // FIXME local data only?
+            tree.getOrPut(task.remoteId ?: task.id.toString()) { mutableListOf() }
         } else {
             // Add child task under its parent's list of children
             tree.getOrPut(parentId) { mutableListOf() }.add(task)
@@ -153,7 +153,7 @@ fun sortTasksManualOrdering(tasks: List<TaskEntity>): List<Pair<TaskEntity, Int>
         result.add(task to level)
         val children = tree[taskId] ?: return
         for (child in children) {
-            traverseTasks(child.remoteId ?: "", level + 1, result) // FIXME local data only?
+            traverseTasks(child.remoteId ?: child.id.toString(), level + 1, result)
         }
     }
 

--- a/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/entity/TaskEntity.kt
+++ b/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/entity/TaskEntity.kt
@@ -51,7 +51,7 @@ data class TaskEntity(
     @ColumnInfo(name = "is_completed")
     val isCompleted: Boolean = false,
     @ColumnInfo(name = "position")
-    val position: String, // FIXME how to adopt this for local only tasks?
+    val position: String,
     @ColumnInfo(name = "parent_local_id")
     val parentTaskLocalId: Long? = null,
     @ColumnInfo(name = "remote_parent_id")

--- a/tasks-core/src/commonTest/kotlin/net/opatry/tasks/data/TaskSortingTest.kt
+++ b/tasks-core/src/commonTest/kotlin/net/opatry/tasks/data/TaskSortingTest.kt
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2024 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.tasks.data
+
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import net.opatry.tasks.data.entity.TaskEntity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TaskSortingTest {
+
+    @Test
+    fun `minimum completed date sorting position`() {
+        // minimum timestamp sorting value (1970-01-01T00:00:00Z)
+        val tMin = LocalDateTime(1970, 1, 1, 0, 0, 0).toInstant(TimeZone.UTC)
+        assertEquals("09999999999999999999", tMin.asCompletedTaskPosition())
+    }
+
+    @Test
+    fun `arbitrary completed date sorting position`() {
+        // an arbitrary timestamp (2024-10-29T15:54:12Z)
+        val t = LocalDateTime(2024, 10, 29, 15, 54, 12).toInstant(TimeZone.UTC)
+        assertEquals("09999998269782747999", t.asCompletedTaskPosition())
+    }
+
+    @Test
+    fun `maximum completed date sorting position`() {
+        // RFC 3339 timestamp supposed maximum value (9999-12-31T23:59:59Z)
+        val tMax = LocalDateTime(9999, 12, 31, 23, 59, 59).toInstant(TimeZone.UTC)
+        assertEquals("09999746597699200999", tMax.asCompletedTaskPosition())
+    }
+
+    @Test
+    fun `last completed task is sorted first`() {
+        val completedTasks = listOf(
+            TaskEntity(
+                id = 1,
+                title = "t1",
+                parentListLocalId = 0,
+                lastUpdateDate = LocalDateTime(2024, 10, 28, 12, 0, 0).toInstant(TimeZone.UTC),
+                isCompleted = true,
+                completionDate = LocalDateTime(2024, 10, 28, 12, 0, 0).toInstant(TimeZone.UTC),
+                position = ""
+            ),
+            TaskEntity(
+                id = 2,
+                title = "t2",
+                parentListLocalId = 0,
+                lastUpdateDate = LocalDateTime(2024, 10, 29, 12, 0, 0).toInstant(TimeZone.UTC),
+                isCompleted = true,
+                completionDate = LocalDateTime(2024, 10, 29, 12, 0, 0).toInstant(TimeZone.UTC),
+                position = ""
+            ),
+        )
+
+        val sortedTasks = computeTaskPositions(completedTasks)
+
+        assertEquals(completedTasks.size, sortedTasks.size)
+        assertEquals(2, sortedTasks[0].id)
+        assertEquals("09999998269796799999", sortedTasks[0].position)
+        assertEquals(1, sortedTasks[1].id)
+        assertEquals("09999998269883199999", sortedTasks[1].position)
+    }
+
+    @Test
+    fun `completed tasks comes after others`() {
+        val tasks = listOf(
+            TaskEntity(
+                id = 0,
+                title = "t1",
+                parentListLocalId = 0,
+                lastUpdateDate = LocalDateTime(2024, 10, 28, 12, 0, 0).toInstant(TimeZone.UTC),
+                isCompleted = false,
+                completionDate = null,
+                position = ""
+            ),
+            TaskEntity(
+                id = 1,
+                title = "t2",
+                parentListLocalId = 0,
+                lastUpdateDate = LocalDateTime(2024, 10, 28, 12, 0, 0).toInstant(TimeZone.UTC),
+                isCompleted = false,
+                completionDate = null,
+                position = ""
+            ),
+            TaskEntity(
+                id = 2,
+                title = "t3",
+                parentListLocalId = 0,
+                lastUpdateDate = LocalDateTime(2024, 10, 28, 12, 0, 0).toInstant(TimeZone.UTC),
+                isCompleted = true,
+                completionDate = LocalDateTime(2024, 10, 28, 12, 0, 0).toInstant(TimeZone.UTC),
+                position = ""
+            ),
+            TaskEntity(
+                id = 3,
+                title = "t4",
+                parentListLocalId = 0,
+                lastUpdateDate = LocalDateTime(2024, 10, 29, 12, 0, 0).toInstant(TimeZone.UTC),
+                isCompleted = true,
+                completionDate = LocalDateTime(2024, 10, 29, 12, 0, 0).toInstant(TimeZone.UTC),
+                position = ""
+            ),
+        )
+
+        val sortedTasks = computeTaskPositions(tasks)
+
+        assertEquals(tasks.size, sortedTasks.size)
+        assertEquals(0, sortedTasks[0].id)
+        assertEquals("00000000000000000000", sortedTasks[0].position)
+        assertEquals(1, sortedTasks[1].id)
+        assertEquals("00000000000000000001", sortedTasks[1].position)
+        assertEquals(tasks.size, sortedTasks.size)
+        assertEquals(3, sortedTasks[2].id)
+        assertEquals("09999998269796799999", sortedTasks[2].position)
+        assertEquals(2, sortedTasks[3].id)
+        assertEquals("09999998269883199999", sortedTasks[3].position)
+    }
+
+    @Test
+    fun `sorting of tasks is clustered by list`() {
+        val tasks = listOf(
+            TaskEntity(
+                id = 0,
+                title = "t1",
+                parentListLocalId = 0,
+                lastUpdateDate = LocalDateTime(2024, 10, 28, 12, 0, 0).toInstant(TimeZone.UTC),
+                isCompleted = false,
+                completionDate = null,
+                position = ""
+            ),
+            TaskEntity(
+                id = 1,
+                title = "t2",
+                parentListLocalId = 1,
+                lastUpdateDate = LocalDateTime(2024, 10, 28, 12, 0, 0).toInstant(TimeZone.UTC),
+                isCompleted = false,
+                completionDate = null,
+                position = ""
+            ),
+            TaskEntity(
+                id = 2,
+                title = "t3",
+                parentListLocalId = 1,
+                lastUpdateDate = LocalDateTime(2024, 10, 28, 12, 0, 0).toInstant(TimeZone.UTC),
+                isCompleted = false,
+                completionDate = null,
+                position = ""
+            ),
+        )
+
+        val sortedTasks = computeTaskPositions(tasks)
+
+        // position is reset for each list
+        assertEquals(tasks.size, sortedTasks.size)
+        assertEquals(0, sortedTasks[0].id)
+        assertEquals("00000000000000000000", sortedTasks[0].position)
+        assertEquals(1, sortedTasks[1].id)
+        assertEquals("00000000000000000000", sortedTasks[1].position)
+        assertEquals(2, sortedTasks[2].id)
+        assertEquals("00000000000000000001", sortedTasks[2].position)
+    }
+
+    @Test
+    fun `sorting of tasks is clustered by parent task`() {
+        val tasks = listOf(
+            TaskEntity(
+                id = 0,
+                title = "t1",
+                parentListLocalId = 0,
+                parentTaskLocalId = 0,
+                lastUpdateDate = LocalDateTime(2024, 10, 28, 12, 0, 0).toInstant(TimeZone.UTC),
+                isCompleted = false,
+                completionDate = null,
+                position = ""
+            ),
+            TaskEntity(
+                id = 1,
+                title = "t2",
+                parentListLocalId = 0,
+                parentTaskLocalId = 1,
+                lastUpdateDate = LocalDateTime(2024, 10, 28, 12, 0, 0).toInstant(TimeZone.UTC),
+                isCompleted = false,
+                completionDate = null,
+                position = ""
+            ),
+            TaskEntity(
+                id = 2,
+                title = "t3",
+                parentListLocalId = 0,
+                parentTaskLocalId = 1,
+                lastUpdateDate = LocalDateTime(2024, 10, 28, 12, 0, 0).toInstant(TimeZone.UTC),
+                isCompleted = false,
+                completionDate = null,
+                position = ""
+            ),
+        )
+
+        val sortedTasks = computeTaskPositions(tasks)
+
+        // position is reset for each parent task
+        assertEquals(tasks.size, sortedTasks.size)
+        assertEquals(0, sortedTasks[0].id)
+        assertEquals("00000000000000000000", sortedTasks[0].position)
+        assertEquals(1, sortedTasks[1].id)
+        assertEquals("00000000000000000000", sortedTasks[1].position)
+        assertEquals(2, sortedTasks[2].id)
+        assertEquals("00000000000000000001", sortedTasks[2].position)
+    }
+}


### PR DESCRIPTION
### Description
Compute sorting value for local only tasks reusing Google Tasks logic.
- todo tasks uses index padded by up to 20 `0`
- completed tasks uses a maximum bound - completion date padded by up to 20 `0`
- See retro engineering analysis made in #125

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
