### PR TITLE
Recompute task positions on task deletion

### DIFF
--- a/tasks-app-shared/src/commonTest/kotlin/net/opatry/tasks/data/TaskRepositoryCRUDTest.kt
+++ b/tasks-app-shared/src/commonTest/kotlin/net/opatry/tasks/data/TaskRepositoryCRUDTest.kt
@@ -171,6 +171,20 @@ class TaskRepositoryCRUDTest {
     }
 
     @Test
+    fun `delete task should recompute remaining tasks positions`() = runTaskRepositoryTest { repository ->
+        val (taskList, task1) = repository.createAndGetTask("My tasks", "task1")
+        val task2 = repository.createAndGetTask(taskList.id, "task2")
+
+        repository.deleteTask(task2.id)
+
+        val tasks = repository.findTaskListById(taskList.id)?.tasks
+        assertNotNull(tasks)
+        assertEquals(1, tasks.size, "Task should have been deleted")
+        assertEquals(task1.id, tasks.first().id)
+        assertEquals("00000000000000000000", tasks.first().position, "Task position should have been updated")
+    }
+
+    @Test
     fun `move task to top`() = runTaskRepositoryTest { repository ->
         val (taskList, task1) = repository.createAndGetTask("tasks", "t1")
         val task2 = repository.createAndGetTask(taskList.id, "t2")

--- a/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/TaskRepository.kt
+++ b/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/TaskRepository.kt
@@ -429,6 +429,13 @@ class TaskRepository(
         val taskEntity = requireNotNull(taskDao.getById(taskId)) { "Invalid task id $taskId" }
         // TODO pending deletion?
         taskDao.deleteTask(taskId)
+
+        val tasksToUpdated = taskDao.getTasksFromPositionOnward(taskEntity.parentListLocalId, taskEntity.position)
+        if (tasksToUpdated.isNotEmpty()) {
+            val updatedTasks = computeTaskPositions(tasksToUpdated, newPositionStart = taskEntity.position.toInt())
+            taskDao.upsertAll(updatedTasks)
+        }
+
         // FIXME should already be available in entity, quick & dirty workaround
         val taskListRemoteId = taskEntity.parentTaskRemoteId
             ?: taskListDao.getById(taskEntity.parentListLocalId)?.remoteId


### PR DESCRIPTION
### Description
When deleting a task, remaining tasks positions weren't recomputed.
Not that critical on most cases, but inaccurate and also, breaks "first task" support to allow/disallow "move to top" & "indent" actions. 

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
