### PR TITLE
Repository `TaskList` id improvements

### DIFF
--- a/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/TaskRepository.kt
+++ b/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/TaskRepository.kt
@@ -439,7 +439,6 @@ class TaskRepository(
             taskDao.upsertAll(updatedTasks)
         }
 
-        // FIXME should already be available in entity, quick & dirty workaround
         val parentTaskRemoteId = parentTaskEntity?.remoteId
             ?: parentTaskId?.let { taskListDao.getById(it) }?.remoteId
         if (taskListEntity.remoteId != null) {
@@ -468,9 +467,7 @@ class TaskRepository(
             taskDao.upsertAll(updatedTasks)
         }
 
-        // FIXME should already be available in entity, quick & dirty workaround
-        val taskListRemoteId = taskEntity.parentTaskRemoteId
-            ?: taskListDao.getById(taskEntity.parentListLocalId)?.remoteId
+        val taskListRemoteId = taskListDao.getById(taskEntity.parentListLocalId)?.remoteId
         if (taskListRemoteId != null && taskEntity.remoteId != null) {
             withContext(Dispatchers.IO) {
                 try {
@@ -493,9 +490,7 @@ class TaskRepository(
 
         taskDao.upsert(updatedTaskEntity)
 
-        // FIXME should already be available in entity, quick & dirty workaround
-        val taskListRemoteId = updatedTaskEntity.parentTaskRemoteId
-            ?: taskListDao.getById(updatedTaskEntity.parentListLocalId)?.remoteId
+        val taskListRemoteId = taskListDao.getById(updatedTaskEntity.parentListLocalId)?.remoteId
         if (taskListRemoteId != null && updatedTaskEntity.remoteId != null) {
             val task = withContext(Dispatchers.IO) {
                 try {
@@ -590,9 +585,7 @@ class TaskRepository(
         val updatedTaskEntities = computeTaskPositions(tasksToUpdate)
         taskDao.upsertAll(updatedTaskEntities)
 
-        // FIXME should already be available in entity, quick & dirty workaround
-        val taskListRemoteId = updatedTaskEntity.parentTaskRemoteId
-            ?: taskListDao.getById(updatedTaskEntity.parentListLocalId)?.remoteId
+        val taskListRemoteId = taskListDao.getById(updatedTaskEntity.parentListLocalId)?.remoteId
         if (taskListRemoteId != null && updatedTaskEntity.remoteId != null) {
             val task = withContext(Dispatchers.IO) {
                 try {


### PR DESCRIPTION
### Description
- Only rely on local ids for task ordering
  - Made possible thanks to [#141](https://github.com/opatry/tasks-app/issues/141)
- Some APIs were relying on `parentTaskRemoteId` as task list ID 😱.
  - Relates to [#148](https://github.com/opatry/tasks-app/issues/148)

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
