### PR TITLE
Default task list API

### DIFF
--- a/google/tasks/src/commonMain/kotlin/net/opatry/google/tasks/TaskListsApi.kt
+++ b/google/tasks/src/commonMain/kotlin/net/opatry/google/tasks/TaskListsApi.kt
@@ -53,6 +53,14 @@ interface TaskListsApi {
     suspend fun delete(taskListId: String)
 
     /**
+     * [Returns the authenticated user's default task list](https://developers.google.com/tasks/reference/rest/v1/tasklists/get).
+     * It uses the special `taskListId` value `@default`.
+     *
+     * @return the instance of [TaskList] of the default task list.
+     */
+    suspend fun default(): TaskList
+
+    /**
      * [Returns the authenticated user's specified task list](https://developers.google.com/tasks/reference/rest/v1/tasklists/get).
      *
      * @param taskListId Task list identifier.
@@ -113,6 +121,8 @@ class HttpTaskListsApi(
             throw ClientRequestException(response, response.bodyAsText())
         }
     }
+
+    override suspend fun default() = get("@default")
 
     override suspend fun get(taskListId: String): TaskList {
         val response = httpClient.get("tasks/v1/users/@me/lists/${taskListId}")

--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/presentation/TaskListsViewModel.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/presentation/TaskListsViewModel.kt
@@ -93,6 +93,7 @@ private fun TaskListDataModel.asTaskListUIModel(): TaskListUIModel {
         remainingTasks = taskGroups.toMap(),
         completedTasks = completedTasks,
         sorting = sorting,
+        canDelete = !isDefault,
     )
 }
 

--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/presentation/model/TaskListUIModel.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/presentation/model/TaskListUIModel.kt
@@ -34,6 +34,7 @@ data class TaskListUIModel(
     val remainingTasks: Map<DateRange?, List<TaskUIModel.Todo>> = emptyMap(),
     val completedTasks: List<TaskUIModel.Done> = emptyList(),
     val sorting: TaskListSorting = TaskListSorting.Manual,
+    val canDelete: Boolean = false,
 ) {
     fun containsTask(task: TaskUIModel, includeCompleted: Boolean = false): Boolean {
         return allRemainingTasks.contains(task)
@@ -47,5 +48,4 @@ data class TaskListUIModel(
     val isEmpty: Boolean = allRemainingTasks.isEmpty() && completedTasks.isEmpty()
     val hasCompletedTasks: Boolean = completedTasks.isNotEmpty()
     val isEmptyRemainingTasksVisible: Boolean = allRemainingTasks.isEmpty() && hasCompletedTasks
-    val canDelete: Boolean = true // FIXME default list can't be deleted, how to know it?
 }

--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/component/TaskListEditMenu.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/ui/component/TaskListEditMenu.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import net.opatry.tasks.app.presentation.model.TaskListUIModel
 import net.opatry.tasks.app.ui.component.TaskListEditMenuTestTag.CLEAR_COMPLETED_TASKS
 import net.opatry.tasks.app.ui.component.TaskListEditMenuTestTag.DELETE
+import net.opatry.tasks.app.ui.component.TaskListEditMenuTestTag.DELETE_NOT_ALLOWED_NOTICE
 import net.opatry.tasks.app.ui.component.TaskListEditMenuTestTag.EDIT_MENU
 import net.opatry.tasks.app.ui.component.TaskListEditMenuTestTag.RENAME
 import net.opatry.tasks.resources.Res
@@ -57,6 +58,7 @@ internal object TaskListEditMenuTestTag {
     const val RENAME = "TASK_LIST_RENAME"
     const val CLEAR_COMPLETED_TASKS = "TASK_LIST_CLEAR_COMPLETED_TASKS"
     const val DELETE = "TASK_LIST_DELETE"
+    const val DELETE_NOT_ALLOWED_NOTICE = "TASK_LIST_DELETE_NOT_ALLOWED_NOTICE"
 }
 
 enum class TaskListEditMenuAction {
@@ -108,7 +110,8 @@ fun TaskListEditMenu(
                         RowWithIcon(stringResource(Res.string.task_list_menu_delete), LucideIcons.Trash2)
                         if (!isDeletedAllowed) {
                             Text(
-                                stringResource(Res.string.task_list_menu_default_list_cannot_be_deleted),
+                                text = stringResource(Res.string.task_list_menu_default_list_cannot_be_deleted),
+                                modifier = Modifier.testTag(DELETE_NOT_ALLOWED_NOTICE),
                                 style = MaterialTheme.typography.bodySmall
                             )
                         }

--- a/tasks-app-shared/src/commonTest/kotlin/net/opatry/tasks/data/util/InMemoryTaskListsApi.kt
+++ b/tasks-app-shared/src/commonTest/kotlin/net/opatry/tasks/data/util/InMemoryTaskListsApi.kt
@@ -68,6 +68,14 @@ class InMemoryTaskListsApi(vararg initialTaskLists: String) : TaskListsApi {
         }
     }
 
+    override suspend fun default(): TaskList {
+        return handleRequest("default") {
+            synchronized(this) {
+                storage["1"] ?: error("Task list (@default / 1) not found")
+            }
+        }
+    }
+
     override suspend fun get(taskListId: String): TaskList {
         return handleRequest("get") {
             synchronized(this) {

--- a/tasks-app-shared/src/commonTest/kotlin/net/opatry/tasks/presentation/TaskListsViewModelTest.kt
+++ b/tasks-app-shared/src/commonTest/kotlin/net/opatry/tasks/presentation/TaskListsViewModelTest.kt
@@ -164,6 +164,7 @@ class TaskListsViewModelTest {
                         ),
                     ),
                     sorting = TaskListSorting.DueDate,
+                    isDefault = true,
                 )
             )
         )

--- a/tasks-app-shared/src/commonTest/kotlin/net/opatry/tasks/ui/component/TaskListEditMenuTest.kt
+++ b/tasks-app-shared/src/commonTest/kotlin/net/opatry/tasks/ui/component/TaskListEditMenuTest.kt
@@ -36,6 +36,7 @@ import net.opatry.tasks.app.ui.component.TaskListEditMenu
 import net.opatry.tasks.app.ui.component.TaskListEditMenuAction
 import net.opatry.tasks.app.ui.component.TaskListEditMenuTestTag.CLEAR_COMPLETED_TASKS
 import net.opatry.tasks.app.ui.component.TaskListEditMenuTestTag.DELETE
+import net.opatry.tasks.app.ui.component.TaskListEditMenuTestTag.DELETE_NOT_ALLOWED_NOTICE
 import net.opatry.tasks.app.ui.component.TaskListEditMenuTestTag.EDIT_MENU
 import net.opatry.tasks.app.ui.component.TaskListEditMenuTestTag.RENAME
 import org.junit.Test
@@ -219,6 +220,28 @@ class TaskListEditMenuTest {
         onNodeWithTag(DELETE)
             .performClick()
 
+        onNodeWithTag(DELETE_NOT_ALLOWED_NOTICE)
+            .assertDoesNotExist()
+
         assertEquals(TaskListEditMenuAction.Delete, action)
+    }
+
+    @Test
+    fun `when list can't be delete then DELETE should be disabled with a notice`() = runComposeUiTest {
+        val taskList = createTaskList(canBeDeleted = false)
+        setContent {
+            TaskListEditMenu(
+                taskList = taskList,
+                expanded = true,
+                onDismiss = {},
+                onAction = {},
+            )
+        }
+
+        onNodeWithTag(DELETE, useUnmergedTree = true)
+            .assertIsNotEnabled()
+
+        onNodeWithTag(DELETE_NOT_ALLOWED_NOTICE, useUnmergedTree = true)
+            .assertIsDisplayed()
     }
 }

--- a/tasks-app-shared/src/commonTest/kotlin/net/opatry/tasks/ui/component/TaskListFactory.kt
+++ b/tasks-app-shared/src/commonTest/kotlin/net/opatry/tasks/ui/component/TaskListFactory.kt
@@ -40,11 +40,13 @@ fun createTaskList(
     title: String = "Task List",
     remainingTaskCount: Int = 0,
     completedTaskCount: Int = 0,
+    canBeDeleted: Boolean = true,
 ) = TaskListUIModel(
     id = TaskListId(TASK_LIST_ID++),
     title = title,
     remainingTasks = mapOf(null to List(remainingTaskCount) { createTask() }),
-    completedTasks = List(completedTaskCount) { createCompletedTask() }
+    completedTasks = List(completedTaskCount) { createCompletedTask() },
+    canDelete = canBeDeleted,
 )
 
 private var TASK_ID = 0L

--- a/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/TaskRepository.kt
+++ b/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/TaskRepository.kt
@@ -97,7 +97,15 @@ private fun TaskListEntity.asTaskListDataModel(tasks: List<TaskEntity>): TaskLis
         title = title,
         lastUpdate = lastUpdateDate,
         tasks = sortedTasks,
-        sorting = sorting
+        sorting = sorting,
+        // FIXME quick & dirty inferred hack to determine the default task list
+        //  remote ID seems to be 32 chars for default list while it is 22 for others.
+        // TODO add a column boolean is_default using TaskListsApi.default() for proper impl
+        isDefault = if (remoteId != null) {
+            remoteId.length > 22
+        } else {
+            id == 1L
+        }
     )
 }
 

--- a/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/model/TaskListDataModel.kt
+++ b/tasks-core/src/commonMain/kotlin/net/opatry/tasks/data/model/TaskListDataModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Olivier Patry
+ * Copyright (c) 2025 Olivier Patry
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the "Software"),
@@ -31,4 +31,5 @@ data class TaskListDataModel(
     val lastUpdate: Instant,
     val tasks: List<TaskDataModel>,
     val sorting: TaskListSorting,
+    val isDefault: Boolean,
 )


### PR DESCRIPTION
### Description
- There is a special Task List ID `@default` that can be used to retrieve the default task list.
- Provide the `TaskListsApi.default()` API to resolve it
- Update data model to allow querying `isDefault` needed to implement `TaskListUIModel.canDelete`
- As a quick & dirty workaround, the `isDefault` is currently inferred from ID size, an upcoming PR should come to implement the remote default API resolution properly.

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
