### PR TITLE
Desktop app edit menu to create lists & tasks

### DIFF
--- a/tasks-app-desktop/build.gradle.kts
+++ b/tasks-app-desktop/build.gradle.kts
@@ -39,6 +39,12 @@ val appName = "Taskfolio"
 val appVersion = libs.versions.tasksApp.name.get()
 val appVersionCode = System.getenv("CI_BUILD_NUMBER")?.toIntOrNull() ?: 1
 
+compose.resources {
+    publicResClass = false
+    packageOfResClass = "net.opatry.tasks.app.resources"
+    generateResClass = always
+}
+
 kotlin {
     jvmToolchain(17)
 

--- a/tasks-app-desktop/src/main/composeResources/values-fr/strings.xml
+++ b/tasks-app-desktop/src/main/composeResources/values-fr/strings.xml
@@ -23,4 +23,5 @@
 <resources>
     <string name="app_menu_edit">Édition</string>
     <string name="app_menu_edit_new_task_list">Nouvelle liste de tâches…</string>
+    <string name="app_menu_edit_new_task">Nouvelle tâche…</string>
 </resources>

--- a/tasks-app-desktop/src/main/composeResources/values-fr/strings.xml
+++ b/tasks-app-desktop/src/main/composeResources/values-fr/strings.xml
@@ -1,0 +1,26 @@
+<!--
+  Copyright (c) 2025 Olivier Patry
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the Software
+  is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+  OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+
+<resources>
+    <string name="app_menu_edit">Édition</string>
+    <string name="app_menu_edit_new_task_list">Nouvelle liste de tâches…</string>
+</resources>

--- a/tasks-app-desktop/src/main/composeResources/values/strings.xml
+++ b/tasks-app-desktop/src/main/composeResources/values/strings.xml
@@ -23,4 +23,5 @@
 <resources>
     <string name="app_menu_edit">Edit</string>
     <string name="app_menu_edit_new_task_list">New task list…</string>
+    <string name="app_menu_edit_new_task">New task…</string>
 </resources>

--- a/tasks-app-desktop/src/main/composeResources/values/strings.xml
+++ b/tasks-app-desktop/src/main/composeResources/values/strings.xml
@@ -1,0 +1,26 @@
+<!--
+  Copyright (c) 2025 Olivier Patry
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the Software
+  is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+  OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+
+<resources>
+    <string name="app_menu_edit">Edit</string>
+    <string name="app_menu_edit_new_task_list">New task list…</string>
+</resources>

--- a/tasks-app-desktop/src/main/kotlin/mainApp.kt
+++ b/tasks-app-desktop/src/main/kotlin/mainApp.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -46,8 +47,10 @@ import net.opatry.tasks.app.presentation.TaskListsViewModel
 import net.opatry.tasks.app.presentation.UserState
 import net.opatry.tasks.app.presentation.UserViewModel
 import net.opatry.tasks.app.ui.TasksApp
+import net.opatry.tasks.app.ui.component.AppMenuBar
 import net.opatry.tasks.app.ui.component.AuthorizeGoogleTasksButton
 import net.opatry.tasks.app.ui.component.LoadingPane
+import net.opatry.tasks.app.ui.component.NewTaskListDialog
 import net.opatry.tasks.app.ui.screen.AboutApp
 import net.opatry.tasks.app.ui.screen.AuthorizationScreen
 import net.opatry.tasks.app.ui.theme.TaskfolioTheme
@@ -79,6 +82,8 @@ fun main() {
             position = WindowPosition(Alignment.Center), width = defaultSize.width, height = defaultSize.height
         )
 
+        var showNewTaskListDialog by remember { mutableStateOf(false) }
+
         Window(
             onCloseRequest = ::exitApplication,
             state = windowState,
@@ -103,6 +108,10 @@ fun main() {
                     )
                 }
             }
+
+            AppMenuBar(
+                onNewTaskListClick = { showNewTaskListDialog = true },
+            )
 
             KoinApplication(application = {
                 modules(
@@ -138,6 +147,17 @@ fun main() {
                                     MainApp::class.java.getResource("/licenses_desktop.json")?.readText() ?: ""
                                 }
                                 val tasksViewModel = koinViewModel<TaskListsViewModel>()
+
+                                if (showNewTaskListDialog) {
+                                    NewTaskListDialog(
+                                        onDismissRequest = { showNewTaskListDialog = false },
+                                        onCreate = { title ->
+                                            showNewTaskListDialog = false
+                                            tasksViewModel.createTaskList(title)
+                                        },
+                                    )
+                                }
+
                                 TasksApp(aboutApp, userViewModel, tasksViewModel)
                             }
 

--- a/tasks-app-desktop/src/main/kotlin/net/opatry/tasks/app/ui/component/AppMenuBar.kt
+++ b/tasks-app-desktop/src/main/kotlin/net/opatry/tasks/app/ui/component/AppMenuBar.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.tasks.app.ui.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyShortcut
+import androidx.compose.ui.window.FrameWindowScope
+import androidx.compose.ui.window.MenuBar
+import net.opatry.tasks.app.resources.Res
+import net.opatry.tasks.app.resources.app_menu_edit
+import net.opatry.tasks.app.resources.app_menu_edit_new_task_list
+import net.opatry.tasks.app.util.OS
+import net.opatry.tasks.app.util.currentOS
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun FrameWindowScope.AppMenuBar(
+    onNewTaskListClick: () -> Unit,
+) {
+    MenuBar {
+        Menu(stringResource(Res.string.app_menu_edit), mnemonic = 'E') {
+            Item(
+                text = stringResource(Res.string.app_menu_edit_new_task_list),
+                shortcut = when (currentOS) {
+                    OS.Mac -> KeyShortcut(key = Key.N, meta = true, shift = true)
+                    OS.Linux,
+                    OS.Windows -> KeyShortcut(key = Key.N, ctrl = true, shift = true)
+                },
+                onClick = onNewTaskListClick
+            )
+        }
+    }
+}

--- a/tasks-app-desktop/src/main/kotlin/net/opatry/tasks/app/ui/component/AppMenuBar.kt
+++ b/tasks-app-desktop/src/main/kotlin/net/opatry/tasks/app/ui/component/AppMenuBar.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.window.FrameWindowScope
 import androidx.compose.ui.window.MenuBar
 import net.opatry.tasks.app.resources.Res
 import net.opatry.tasks.app.resources.app_menu_edit
+import net.opatry.tasks.app.resources.app_menu_edit_new_task
 import net.opatry.tasks.app.resources.app_menu_edit_new_task_list
 import net.opatry.tasks.app.util.OS
 import net.opatry.tasks.app.util.currentOS
@@ -37,6 +38,8 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun FrameWindowScope.AppMenuBar(
     onNewTaskListClick: () -> Unit,
+    canCreateTask: Boolean,
+    onNewTaskClick: () -> Unit,
 ) {
     MenuBar {
         Menu(stringResource(Res.string.app_menu_edit), mnemonic = 'E') {
@@ -48,6 +51,16 @@ fun FrameWindowScope.AppMenuBar(
                     OS.Windows -> KeyShortcut(key = Key.N, ctrl = true, shift = true)
                 },
                 onClick = onNewTaskListClick
+            )
+            Item(
+                text = stringResource(Res.string.app_menu_edit_new_task),
+                shortcut = when (currentOS) {
+                    OS.Mac -> KeyShortcut(key = Key.N, meta = true)
+                    OS.Linux,
+                    OS.Windows -> KeyShortcut(key = Key.N, ctrl = true)
+                },
+                enabled = canCreateTask,
+                onClick = onNewTaskClick
             )
         }
     }

--- a/tasks-app-desktop/src/main/kotlin/net/opatry/tasks/app/util/os.kt
+++ b/tasks-app-desktop/src/main/kotlin/net/opatry/tasks/app/util/os.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.tasks.app.util
+
+enum class OS {
+    Mac,
+    Linux,
+    Windows,
+    ;
+
+    val isMac: Boolean by lazy { this == Mac }
+    val isLinux: Boolean by lazy { this == Linux }
+    val isWindows: Boolean by lazy { this == Windows }
+}
+
+val currentOS: OS by lazy {
+    val osName = System.getProperty("os.name")
+    when {
+        osName.contains("mac", ignoreCase = true) -> OS.Mac
+        osName.matches(Regex("n[iu]x", RegexOption.IGNORE_CASE)) -> OS.Linux
+        else -> OS.Windows
+    }
+}


### PR DESCRIPTION
### Description
- <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd> to create new task list
- <kbd>Cmd</kbd>+<kbd>N</kbd> to create new task

UI test tentative doesn't work, most likely due to menu node not being part of Compose scene.

```kotlin
@Test
fun `when clicking on show network logs then should trigger callback`() = runComposeUiTest {
  var isNetworkLogClicked = false
  setContent {
      Window(
          onCloseRequest = {},
          title = "Test",
      ) {
          AppMenuBar(
              showDevelopmentTools = true,
              onNewTaskListClick = {},
              onNewTaskClick = {},
              onAboutClick = {},
              onNetworkLogClick = { isNetworkLogClicked = true },
          )
      }
  }

  onNodeWithText("Tools")
      .assertIsDisplayed()
      .performClick()

  onNodeWithText("Show network logs")
      .assertIsDisplayed()
      .performClick()
}
```

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
