### PR TITLE
Improve network state notifier tests

### DIFF
--- a/tasks-app-shared/src/jvmMain/kotlin/net/opatry/network/NetworkStatusNotifier.jvm.kt
+++ b/tasks-app-shared/src/jvmMain/kotlin/net/opatry/network/NetworkStatusNotifier.jvm.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.isActive
@@ -78,7 +77,7 @@ class NetworkStatusNotifier(
 
             delay(pollingDelay)
         }
-    }.distinctUntilChanged().flowOn(dispatcher)
+    }.flowOn(dispatcher)
 }
 
 private val notifier = NetworkStatusNotifier()

--- a/tasks-app-shared/src/jvmTest/kotlin/net/opatry/tasks/NetworkStatusNotifierTest.jvm.kt
+++ b/tasks-app-shared/src/jvmTest/kotlin/net/opatry/tasks/NetworkStatusNotifierTest.jvm.kt
@@ -329,4 +329,50 @@ class NetworkStatusNotifierTest {
         advanceTimeBy(50.seconds)
         assertEquals(3, callCount)
     }
+
+    @Test
+    fun `when state is ON from on poll to another should not notify twice`() = runTest {
+        var callCount = 0
+        val notifier = NetworkStatusNotifierTest {
+            ++callCount
+            true
+        }
+
+        val flow = notifier.networkStateFlow()
+
+        val collectedStates = mutableListOf<Boolean>()
+        val collectorJob = launch {
+            flow.toList(collectedStates)
+        }
+
+        advanceTimeBy(15.seconds)
+
+        collectorJob.cancelChildren()
+
+        assertEquals(3, callCount)
+        assertEquals(1, collectedStates.size)
+    }
+
+    @Test
+    fun `when state is OFF from on poll to another should not notify twice`() = runTest {
+        var callCount = 0
+        val notifier = NetworkStatusNotifierTest {
+            ++callCount
+            false
+        }
+
+        val flow = notifier.networkStateFlow()
+
+        val collectedStates = mutableListOf<Boolean>()
+        val collectorJob = launch {
+            flow.toList(collectedStates)
+        }
+
+        advanceTimeBy(15.seconds)
+
+        collectorJob.cancelChildren()
+
+        assertEquals(2, callCount)
+        assertEquals(1, collectedStates.size)
+    }
 }

--- a/tasks-app-shared/src/jvmTest/kotlin/net/opatry/tasks/NetworkStatusNotifierTest.jvm.kt
+++ b/tasks-app-shared/src/jvmTest/kotlin/net/opatry/tasks/NetworkStatusNotifierTest.jvm.kt
@@ -23,6 +23,7 @@
 package net.opatry.tasks
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
@@ -126,7 +127,7 @@ class NetworkStatusNotifierTest {
         }
 
         advanceTimeBy(5.5.seconds)
-        collectorJob.cancel()
+        collectorJob.cancelChildren()
 
         assertEquals(2, collectedStates.size)
         assertTrue(collectedStates.first())
@@ -148,7 +149,7 @@ class NetworkStatusNotifierTest {
         }
 
         advanceTimeBy(5.5.seconds)
-        collectorJob.cancel()
+        collectorJob.cancelChildren()
 
         assertEquals(2, collectedStates.size)
         assertFalse(collectedStates.first())
@@ -175,7 +176,7 @@ class NetworkStatusNotifierTest {
         assertEquals(1, checkTimes.size)
 
         advanceTimeBy(5.seconds)
-        collectorJob.cancel()
+        collectorJob.cancelChildren()
         assertEquals(2, checkTimes.size)
         val t2 = virtualNow()
 
@@ -206,7 +207,7 @@ class NetworkStatusNotifierTest {
         assertEquals(1, checkTimes.size)
 
         advanceTimeBy(5.seconds)
-        collectorJob.cancel()
+        collectorJob.cancelChildren()
         assertEquals(2, checkTimes.size)
         val t2 = virtualNow()
 
@@ -241,7 +242,7 @@ class NetworkStatusNotifierTest {
         advanceTimeBy(10.seconds)
         assertEquals(4, callCount)
 
-        collectorJob.cancel()
+        collectorJob.cancelChildren()
     }
 
     @Test
@@ -276,7 +277,7 @@ class NetworkStatusNotifierTest {
         advanceTimeBy(10.seconds)
         assertEquals(4, callCount)
 
-        collectorJob.cancel()
+        collectorJob.cancelChildren()
     }
 
     @Test
@@ -301,7 +302,7 @@ class NetworkStatusNotifierTest {
         // called 2 times more in 10 seconds
         assertEquals(4, callCount)
 
-        collectorJob.cancel()
+        collectorJob.cancelChildren()
     }
 
     @Test
@@ -323,7 +324,7 @@ class NetworkStatusNotifierTest {
         advanceTimeBy(10.seconds)
         assertEquals(3, callCount)
 
-        collectorJob.cancel()
+        collectorJob.cancelChildren()
 
         advanceTimeBy(50.seconds)
         assertEquals(3, callCount)


### PR DESCRIPTION
### Description
- Use `cancelChildren` in test to stay closer to flow cancellation
- Add test for "dup" notification avoidance and remove the need of useless `distinctUntilChanged`

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
