### PR TITLE
Wait for Idle & increase timeout for E2E UI test

### DIFF
--- a/tasks-app-android/src/androidTest/java/net/opatry/tasks/app/test/e2e/TaskfolioE2ETest.kt
+++ b/tasks-app-android/src/androidTest/java/net/opatry/tasks/app/test/e2e/TaskfolioE2ETest.kt
@@ -88,7 +88,8 @@ class TaskfolioE2ETest {
             .performClick()
 
         // creating a list switches to the tasks screen automatically
-        waitUntilExactlyOneExists(hasTestTag(NO_TASKS_EMPTY_STATE))
+        waitForIdle()
+        waitUntilExactlyOneExists(hasTestTag(NO_TASKS_EMPTY_STATE), timeoutMillis = 5_000)
         onNodeWithTag(NO_TASKS_EMPTY_STATE)
             .assertIsDisplayed()
         onNodeWithText(listTitle)


### PR DESCRIPTION
### Description
- Wait for Idle & increase timeout to wait for navigation done after task list creation

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
