### PR TITLE
Better split of coverage workflow PR vs main branch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,22 +14,18 @@ jobs:
 
     # Avoid using --parallel for coverage reporting, seems unreliable when doing it
     - name: 📊 Check coverage
-      if: github.event_name == 'pull_request'
       run: |
         ./gradlew --no-daemon --console=plain \
-          koverLogCoverage koverVerifyCoverage
+          koverXmlReportCoverage koverLogCoverage koverVerifyCoverage
 
-    # Avoid using --parallel for coverage reporting, seems unreliable when doing it
-    - name: 📊 Check coverage & update badge
+    - name: 🏷️ Update badge
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: |
         sudo apt -y install libxml2-utils
-        ./gradlew --no-daemon  --console=plain \
-          koverXmlReportCoverage koverLogCoverage koverVerifyCoverage
         ./_ci/replace_coverage_badge.sh build/reports/kover/reportCoverage.xml
         if [[ $(git status --porcelain README.md) ]]; then
           git config user.name 'Github Actions'
-          git config user.email 'opatry-tasks-app@users.noreply.github.com'
+          git config user.email 'opatry-h2go-app@users.noreply.github.com'
           git add README.md
           git commit -m "Update coverage badge in README.md"
           git push


### PR DESCRIPTION
### Description
- Code was kinda duplicated
- Whichever setup, coverage was needed, only Xml report was optional, given the cost, let's include it all the time
- Only the main pushes updates the coverage badge relying on previous step state

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
