### PR TITLE
Improve devx for developer not having access to project's secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,24 @@ I do not aim to implement advanced features beyond what is supported by the Goog
 <details>
 <summary>See details…</summary>
 
+### Production setup
+
+If you have access to the project’s secrets, you can decrypt the encrypted files using the following procedure:
+
 Decrypt `*.gpg` files needed for development, and copy decrypted versions in proper places.
 
 ```bash
 PLAYSTORE_SECRET_PASSPHRASE=MY_SECRET ./_ci/decrypt_secrets.sh
+```
+
+### Stub setup
+
+Alternatively, you can stub the necessary files to make the project compile.
+The release signing config is irrelevant for local development and can be ignored.
+As for `google-services.json`, a simple stub is sufficient for local setup.
+
+```bash
+./_ci/stub_secrets.sh
 ```
 
 ### Updating `google-services.json`

--- a/_ci/stub_secrets.sh
+++ b/_ci/stub_secrets.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+origin=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || exit
+root=$(cd "${origin}/.." && pwd)
+
+src="${root}/tasks-app-android/src/dev/google-services.json"
+dst="${root}/tasks-app-android/google-services.json"
+
+cp "${src}" "${dst}"
+sed -i.bak 's/net\.opatry\.tasks\.app\.dev/net.opatry.tasks.app/g' "${dst}"
+rm "${dst}.bak"


### PR DESCRIPTION
### Description
Was hard to understand how to build the project when not having access to project's secrets.
This provides a convenience script to stub mandatory files for local development.

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
