### PR TITLE
Add `TaskPosition` abstraction layer to hide `BigInteger` implementation detail

### DIFF
--- a/tasks-app-shared/src/androidMain/kotlin/net/opatry/tasks/app/ui/component/TaskEditorBottomSheetPreview.kt
+++ b/tasks-app-shared/src/androidMain/kotlin/net/opatry/tasks/app/ui/component/TaskEditorBottomSheetPreview.kt
@@ -39,12 +39,12 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import kotlinx.datetime.LocalDate
+import net.opatry.tasks.TodoTaskPosition
 import net.opatry.tasks.app.presentation.model.TaskId
 import net.opatry.tasks.app.presentation.model.TaskListId
 import net.opatry.tasks.app.presentation.model.TaskListUIModel
 import net.opatry.tasks.app.presentation.model.TaskUIModel
 import net.opatry.tasks.app.ui.tooling.TaskfolioThemedPreview
-import net.opatry.tasks.data.toTaskPosition
 
 private data class TaskEditorPreviewData(
     val editMode: TaskEditMode,
@@ -74,7 +74,7 @@ private class TaskEditorPreviewParameterProvider : PreviewParameterProvider<Task
                     id = TaskId(0),
                     title = "My edited task",
                     dueDate = LocalDate(2018, 6, 23),
-                    position = 0.toTaskPosition(),
+                    position = TodoTaskPosition.fromIndex(0),
                 ),
                 taskList = TaskListUIModel(
                     id = TaskListId(0),

--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/presentation/TaskListsViewModel.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/presentation/TaskListsViewModel.kt
@@ -43,6 +43,8 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.toLocalDateTime
 import net.opatry.logging.Logger
+import net.opatry.tasks.DoneTaskPosition
+import net.opatry.tasks.TodoTaskPosition
 import net.opatry.tasks.app.presentation.model.DateRange
 import net.opatry.tasks.app.presentation.model.TaskId
 import net.opatry.tasks.app.presentation.model.TaskListId
@@ -54,7 +56,6 @@ import net.opatry.tasks.data.TaskListSorting
 import net.opatry.tasks.data.TaskRepository
 import net.opatry.tasks.data.model.TaskDataModel
 import net.opatry.tasks.data.model.TaskListDataModel
-import net.opatry.tasks.data.toTaskPosition
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -110,16 +111,16 @@ internal fun TaskDataModel.asTaskUIModel(): TaskUIModel {
             notes = notes,
             dueDate = dueDate,
             completionDate = requireNotNull(completionDate).toLocalDateTime(TimeZone.UTC).date,
-            position = position,
+            position = DoneTaskPosition.fromPosition(position),
         )
     } else {
-        val isFirstTask = position == 0.toTaskPosition()
+        val isFirstTask = position.toIntOrNull() == 0
         TaskUIModel.Todo(
             id = TaskId(id),
             title = title,
             notes = notes,
             dueDate = dueDate,
-            position = position,
+            position = TodoTaskPosition.fromPosition(position),
             indent = indent,
             canMoveToTop = indent == 0 && !isFirstTask,
             canUnindent = indent > 0,

--- a/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/presentation/model/TaskUIModel.kt
+++ b/tasks-app-shared/src/commonMain/kotlin/net/opatry/tasks/app/presentation/model/TaskUIModel.kt
@@ -23,12 +23,14 @@
 package net.opatry.tasks.app.presentation.model
 
 import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.daysUntil
 import kotlinx.datetime.toLocalDateTime
-import net.opatry.tasks.data.toTaskPosition
-import java.math.BigInteger
+import net.opatry.tasks.DoneTaskPosition
+import net.opatry.tasks.TaskPosition
+import net.opatry.tasks.TodoTaskPosition
 import kotlin.jvm.JvmInline
 
 sealed class DateRange {
@@ -61,7 +63,7 @@ sealed interface TaskUIModel {
     val id: TaskId
     val title: String
     val notes: String
-    val position: String
+    val position: TaskPosition
     val dueDate: LocalDate?
 
     val dateRange: DateRange
@@ -85,7 +87,7 @@ sealed interface TaskUIModel {
         override val title: String,
         override val dueDate: LocalDate? = null,
         override val notes: String = "",
-        override val position: String = 0.toTaskPosition(),
+        override val position: TodoTaskPosition = TodoTaskPosition.fromIndex(0),
         val indent: Int = 0,
         val canMoveToTop: Boolean = false,
         val canUnindent: Boolean = false,
@@ -97,7 +99,7 @@ sealed interface TaskUIModel {
         override val id: TaskId,
         override val title: String,
         override val notes: String = "",
-        override val position: String = BigInteger("9999999999999999999").toTaskPosition(),
+        override val position: DoneTaskPosition = DoneTaskPosition.fromCompletionDate(Instant.fromEpochMilliseconds(0)),
         override val dueDate: LocalDate? = null,
         val completionDate: LocalDate,
     ) : TaskUIModel

--- a/tasks-app-shared/src/commonTest/kotlin/net/opatry/tasks/data/util/InMemoryTasksApi.kt
+++ b/tasks-app-shared/src/commonTest/kotlin/net/opatry/tasks/data/util/InMemoryTasksApi.kt
@@ -31,7 +31,6 @@ import net.opatry.google.tasks.TasksApi
 import net.opatry.google.tasks.model.ResourceListResponse
 import net.opatry.google.tasks.model.ResourceType
 import net.opatry.google.tasks.model.Task
-import net.opatry.tasks.data.toTaskPosition
 import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
@@ -66,7 +65,7 @@ class InMemoryTasksApi(
         return tasks.map { task ->
             val position = nextPositions.getOrElse(task.parent) { 0 }
             nextPositions[task.parent] = position + 1
-            task.copy(position = position.toTaskPosition())
+            task.copy(position = position.toString().padStart(20, '0'))
         }
     }
 

--- a/tasks-app-shared/src/commonTest/kotlin/net/opatry/tasks/presentation/model/TaskUIModelMapperTest.kt
+++ b/tasks-app-shared/src/commonTest/kotlin/net/opatry/tasks/presentation/model/TaskUIModelMapperTest.kt
@@ -28,6 +28,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
+import net.opatry.tasks.TodoTaskPosition
 import net.opatry.tasks.app.presentation.asTaskUIModel
 import net.opatry.tasks.app.presentation.model.TaskUIModel
 import net.opatry.tasks.data.model.TaskDataModel
@@ -70,7 +71,7 @@ class TaskUIModelMapperTest {
         assertEquals("title", taskUIModel.title)
         assertEquals("notes", taskUIModel.notes)
         assertEquals(date, taskUIModel.dueDate)
-        assertEquals("00000000000000000042", taskUIModel.position)
+        assertEquals(TodoTaskPosition.fromPosition("00000000000000000042"), taskUIModel.position)
         assertEquals(1, taskUIModel.indent)
     }
 

--- a/tasks-app-shared/src/jvmTest/kotlin/net/opatry/tasks/presentation/TaskListsViewModelTest.kt
+++ b/tasks-app-shared/src/jvmTest/kotlin/net/opatry/tasks/presentation/TaskListsViewModelTest.kt
@@ -43,6 +43,8 @@ import kotlinx.datetime.plus
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 import net.opatry.logging.Logger
+import net.opatry.tasks.DoneTaskPosition
+import net.opatry.tasks.TodoTaskPosition
 import net.opatry.tasks.app.presentation.TaskListsViewModel
 import net.opatry.tasks.app.presentation.model.DateRange
 import net.opatry.tasks.app.presentation.model.TaskId
@@ -188,7 +190,7 @@ class TaskListsViewModelTest {
                         title = "task2",
                         dueDate = LastWeek,
                         notes = "notes2",
-                        position = "00000000000000000001",
+                        position = TodoTaskPosition.fromPosition("00000000000000000001"),
                         indent = 0,
                         canMoveToTop = true,
                         canUnindent = false,
@@ -202,7 +204,7 @@ class TaskListsViewModelTest {
                         title = "task1",
                         dueDate = NextWeek,
                         notes = "notes1",
-                        position = "00000000000000000000",
+                        position = TodoTaskPosition.fromPosition("00000000000000000000"),
                         indent = 0,
                         canMoveToTop = false,
                         canUnindent = false,
@@ -222,7 +224,7 @@ class TaskListsViewModelTest {
                     dueDate = null,
                     notes = "notes3",
                     completionDate = yesterday,
-                    position = "09999999999999999999",
+                    position = DoneTaskPosition.fromPosition("09999999999999999999"),
                 )
             ),
             taskList.completedTasks

--- a/tasks-core/src/commonMain/kotlin/net/opatry/tasks/TaskPosition.kt
+++ b/tasks-core/src/commonMain/kotlin/net/opatry/tasks/TaskPosition.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.tasks
+
+import kotlinx.datetime.Instant
+
+interface TaskPosition : Comparable<TaskPosition> {
+    val value: String
+}
+
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+expect class TodoTaskPosition : TaskPosition {
+    companion object {
+        fun fromIndex(index: Int): TodoTaskPosition
+        fun fromPosition(position: String): TodoTaskPosition
+    }
+
+    override val value: String
+    override fun compareTo(other: TaskPosition): Int
+    override fun hashCode(): Int
+    override fun equals(other: Any?): Boolean
+    override fun toString(): String
+}
+
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+expect class DoneTaskPosition : TaskPosition {
+    companion object {
+        fun fromCompletionDate(completionDate: Instant): DoneTaskPosition
+        fun fromPosition(position: String): DoneTaskPosition
+    }
+
+    override val value: String
+    override fun compareTo(other: TaskPosition): Int
+    override fun hashCode(): Int
+    override fun equals(other: Any?): Boolean
+    override fun toString(): String
+}

--- a/tasks-core/src/commonTest/kotlin/net/opatry/tasks/DoneTaskPositionTest.kt
+++ b/tasks-core/src/commonTest/kotlin/net/opatry/tasks/DoneTaskPositionTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.tasks
+
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class DoneTaskPositionTest {
+
+    @Test
+    fun `given completion date when fromCompletionDate then should create position with correct format`() {
+        // Given
+        val completionDate = Instant.fromEpochMilliseconds(1000)
+
+        // When
+        val position = DoneTaskPosition.fromCompletionDate(completionDate)
+
+        // Then
+        assertEquals(20, position.value.length)
+        assertTrue(position.value.all(Char::isDigit))
+        assertEquals("09999999999999998999", position.value)
+    }
+
+    @Test
+    fun `given zero timestamp when fromCompletionDate then should handle zero timestamp correctly`() {
+        // Given
+        val completionDate = Instant.fromEpochMilliseconds(0)
+
+        // When
+        val position = DoneTaskPosition.fromCompletionDate(completionDate)
+
+        // Then
+        assertEquals("09999999999999999999", position.value)
+    }
+
+    @Test
+    fun `given large timestamp when fromCompletionDate then should handle large timestamp correctly`() {
+        // Given
+        val completionDate = Instant.fromEpochMilliseconds(9999999999999999L)
+
+        // When
+        val position = DoneTaskPosition.fromCompletionDate(completionDate)
+
+        // Then
+        assertEquals("09990000000000000000", position.value)
+    }
+
+    @Test
+    fun `given valid position string when fromPosition then should create position correctly`() {
+        // Given
+        val positionString = "09999999999999998999"
+
+        // When
+        val position = DoneTaskPosition.fromPosition(positionString)
+
+        // Then
+        assertEquals(positionString, position.value)
+    }
+
+    @Test
+    fun `given non-numeric string when fromPosition then should throw IllegalArgumentException`() {
+        // Given
+        val nonNumericString = "abcd999999999999999"
+
+        // When & Then
+        assertFailsWith<IllegalArgumentException> {
+            DoneTaskPosition.fromPosition(nonNumericString)
+        }
+    }
+
+    @Test
+    fun `given different completion dates when compareTo then should compare in reverse chronological order`() {
+        // Given
+        val earlier = Instant.fromEpochMilliseconds(1000)
+        val later = Instant.fromEpochMilliseconds(2000)
+        val pos1 = DoneTaskPosition.fromCompletionDate(earlier)
+        val pos2 = DoneTaskPosition.fromCompletionDate(later)
+
+        // When & Then
+        assertTrue(pos1 > pos2)
+        assertTrue(pos2 < pos1)
+    }
+
+    @Test
+    fun `given same completion date when compareTo then should be equal`() {
+        // Given
+        val completionDate = Instant.fromEpochMilliseconds(1000)
+        val pos1 = DoneTaskPosition.fromCompletionDate(completionDate)
+        val pos2 = DoneTaskPosition.fromCompletionDate(completionDate)
+
+        // When & Then
+        assertEquals(0, pos1.compareTo(pos2))
+    }
+
+    @Test
+    fun `given DoneTaskPositions with same completion date when equals and hashCode then should be equal with same hashCode`() {
+        // Given
+        val completionDate = Instant.fromEpochMilliseconds(1000)
+        val pos1 = DoneTaskPosition.fromCompletionDate(completionDate)
+        val pos2 = DoneTaskPosition.fromCompletionDate(completionDate)
+        val pos3 = DoneTaskPosition.fromCompletionDate(Instant.fromEpochMilliseconds(2000))
+
+        // When & Then
+        assertEquals(pos1, pos2)
+        assertNotEquals(pos1, pos3)
+        assertEquals(pos1.hashCode(), pos2.hashCode())
+        assertNotEquals(pos1.hashCode(), pos3.hashCode())
+    }
+
+    @Test
+    fun `given DoneTaskPosition when toString then should return meaningful representation`() {
+        // Given
+        val position = DoneTaskPosition.fromCompletionDate(Instant.fromEpochMilliseconds(1000))
+
+        // When
+        val result = position.toString()
+
+        // Then
+        assertEquals(20, result.length)
+        assertEquals("09999999999999998999", result)
+    }
+
+    @Test
+    fun `given DoneTaskPosition and invalid TaskPosition type when compareTo then should throw IllegalArgumentException`() {
+        // Given
+        val donePos = DoneTaskPosition.fromCompletionDate(Instant.fromEpochMilliseconds(1000))
+        val invalidTaskPosition = object : TaskPosition {
+            override val value: String = "12345678901234567890"
+            override fun compareTo(other: TaskPosition): Int = 0
+        }
+
+        // When & Then
+        assertFailsWith<IllegalArgumentException> {
+            donePos.compareTo(invalidTaskPosition)
+        }
+    }
+
+    @Test
+    fun `given DoneTaskPosition and invalid object type when equals then should return false`() {
+        // Given
+        val donePos = DoneTaskPosition.fromCompletionDate(Instant.fromEpochMilliseconds(1000))
+        val invalidObject = "not a TaskPosition"
+
+        // When
+        val result = donePos.equals(invalidObject)
+
+        // Then
+        assertFalse(result)
+    }
+}

--- a/tasks-core/src/commonTest/kotlin/net/opatry/tasks/TaskPositionTest.kt
+++ b/tasks-core/src/commonTest/kotlin/net/opatry/tasks/TaskPositionTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.tasks
+
+import kotlinx.datetime.Instant
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TaskPositionTest {
+
+    @Test
+    fun `given TodoTaskPosition and DoneTaskPosition when compareTo then should maintain workflow order`() {
+        // Given
+        val todoPos = TodoTaskPosition.fromIndex(999999999)
+        val donePos = DoneTaskPosition.fromCompletionDate(Instant.fromEpochMilliseconds(0))
+
+        // When & Then
+        assertTrue(todoPos < donePos)
+        assertTrue(donePos > todoPos)
+    }
+
+    @Test
+    fun `given mixed task positions when sorted then should maintain task workflow order`() {
+        // Given
+        val todo1 = TodoTaskPosition.fromIndex(1)
+        val todo2 = TodoTaskPosition.fromIndex(2)
+        val done1 = DoneTaskPosition.fromCompletionDate(Instant.fromEpochMilliseconds(2000)) // completed later
+        val done2 = DoneTaskPosition.fromCompletionDate(Instant.fromEpochMilliseconds(1000)) // completed earlier
+        val positions = listOf(done1, todo2, done2, todo1)
+
+        // When
+        val sorted = positions.sorted()
+
+        // Then
+        assertEquals(listOf(todo1, todo2, done1, done2), sorted)
+    }
+
+    @Test
+    fun `given task positions when accessing value property then should return correct 20-character string`() {
+        // Given
+        val todoPos = TodoTaskPosition.fromIndex(42)
+        val donePos = DoneTaskPosition.fromCompletionDate(Instant.fromEpochMilliseconds(1000))
+
+        // When & Then
+        assertEquals(20, todoPos.value.length)
+        assertEquals(20, donePos.value.length)
+        assertTrue(todoPos.value.all(Char::isDigit))
+        assertTrue(donePos.value.all(Char::isDigit))
+    }
+
+    @Test
+    fun `given task positions when roundtrip serialization then should recreate equal objects`() {
+        // Given
+        val originalTodo = TodoTaskPosition.fromIndex(123)
+        val originalDone = DoneTaskPosition.fromCompletionDate(Instant.fromEpochMilliseconds(5000))
+
+        // When
+        val recreatedTodo = TodoTaskPosition.fromPosition(originalTodo.value)
+        val recreatedDone = DoneTaskPosition.fromPosition(originalDone.value)
+
+        // Then
+        assertEquals(originalTodo, recreatedTodo)
+        assertEquals(originalDone, recreatedDone)
+    }
+
+    @Test
+    fun `given boundary values when creating positions then should work correctly`() {
+        // Given
+        val maxIndex = Int.MAX_VALUE
+        val maxTimestamp = 999999999999999999L
+
+        // When
+        val maxTodo = TodoTaskPosition.fromIndex(maxIndex)
+        val maxDone = DoneTaskPosition.fromCompletionDate(Instant.fromEpochMilliseconds(maxTimestamp))
+
+        // Then
+        assertEquals(20, maxTodo.value.length)
+        assertEquals(20, maxDone.value.length)
+        assertEquals("00000000002147483647", maxTodo.value)
+        assertEquals("09000000000000000000", maxDone.value)
+    }
+}

--- a/tasks-core/src/commonTest/kotlin/net/opatry/tasks/TodoTaskPositionTest.kt
+++ b/tasks-core/src/commonTest/kotlin/net/opatry/tasks/TodoTaskPositionTest.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.tasks
+
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class TodoTaskPositionTest {
+
+    @Test
+    fun `given index 42 when fromIndex then should create position with correct 20-char zero-padded value`() {
+        // Given
+        val index = 42
+
+        // When
+        val position = TodoTaskPosition.fromIndex(index)
+
+        // Then
+        assertEquals(20, position.value.length)
+        assertEquals("00000000000000000042", position.value)
+    }
+
+    @Test
+    fun `given index 0 when fromIndex then should handle zero index correctly`() {
+        // Given
+        val index = 0
+
+        // When
+        val position = TodoTaskPosition.fromIndex(index)
+
+        // Then
+        assertEquals("00000000000000000000", position.value)
+    }
+
+    @Test
+    fun `given large index when fromIndex then should handle large numbers correctly`() {
+        // Given
+        val index = 999999999
+
+        // When
+        val position = TodoTaskPosition.fromIndex(index)
+
+        // Then
+        assertEquals("00000000000999999999", position.value)
+    }
+
+    @Test
+    fun `given valid position string when fromPosition then should create position correctly`() {
+        // Given
+        val positionString = "00000000000000000123"
+
+        // When
+        val position = TodoTaskPosition.fromPosition(positionString)
+
+        // Then
+        assertEquals(positionString, position.value)
+    }
+
+    @Test
+    fun `given non-numeric string when fromPosition then should throw IllegalArgumentException`() {
+        // Given
+        val nonNumericString = "abcd000000000000000"
+
+        // When & Then
+        assertFailsWith<IllegalArgumentException> {
+            TodoTaskPosition.fromPosition(nonNumericString)
+        }
+    }
+
+    @Test
+    fun `given different TodoTaskPositions when compareTo then should compare correctly`() {
+        // Given
+        val pos1 = TodoTaskPosition.fromIndex(10)
+        val pos2 = TodoTaskPosition.fromIndex(20)
+        val pos3 = TodoTaskPosition.fromIndex(10)
+
+        // When & Then
+        assertTrue(pos1 < pos2)
+        assertTrue(pos2 > pos1)
+        assertEquals(0, pos1.compareTo(pos3))
+    }
+
+    @Test
+    fun `given TodoTaskPosition and DoneTaskPosition when compareTo then TodoTaskPosition should be smaller`() {
+        // Given
+        val todoPos = TodoTaskPosition.fromIndex(100)
+        val donePos = DoneTaskPosition.fromCompletionDate(Instant.fromEpochMilliseconds(1000))
+
+        // When & Then
+        assertTrue(todoPos < donePos)
+        assertTrue(donePos > todoPos)
+    }
+
+    @Test
+    fun `given TodoTaskPositions with same index when equals and hashCode then should be equal with same hashCode`() {
+        // Given
+        val pos1 = TodoTaskPosition.fromIndex(42)
+        val pos2 = TodoTaskPosition.fromIndex(42)
+        val pos3 = TodoTaskPosition.fromIndex(43)
+
+        // When & Then
+        assertEquals(pos1, pos2)
+        assertNotEquals(pos1, pos3)
+        assertEquals(pos1.hashCode(), pos2.hashCode())
+        assertNotEquals(pos1.hashCode(), pos3.hashCode())
+    }
+
+    @Test
+    fun `given TodoTaskPosition when toString then should return meaningful representation`() {
+        // Given
+        val position = TodoTaskPosition.fromIndex(42)
+
+        // When
+        val result = position.toString()
+
+        // Then
+        assertEquals(20, result.length)
+        assertEquals("00000000000000000042", result)
+    }
+
+    @Test
+    fun `given TodoTaskPosition and invalid TaskPosition type when compareTo then should throw IllegalArgumentException`() {
+        // Given
+        val todoPos = TodoTaskPosition.fromIndex(42)
+        val invalidTaskPosition = object : TaskPosition {
+            override val value: String = "12345678901234567890"
+            override fun compareTo(other: TaskPosition): Int = 0
+        }
+
+        // When & Then
+        assertFailsWith<IllegalArgumentException> {
+            todoPos.compareTo(invalidTaskPosition)
+        }
+    }
+
+    @Test
+    fun `given TodoTaskPosition and invalid object type when equals then should return false`() {
+        // Given
+        val todoPos = TodoTaskPosition.fromIndex(42)
+        val invalidObject = "not a TaskPosition"
+
+        // When
+        val result = todoPos.equals(invalidObject)
+
+        // Then
+        assertFalse(result)
+    }
+}

--- a/tasks-core/src/commonTest/kotlin/net/opatry/tasks/data/TaskSortingTest.kt
+++ b/tasks-core/src/commonTest/kotlin/net/opatry/tasks/data/TaskSortingTest.kt
@@ -25,6 +25,7 @@ package net.opatry.tasks.data
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
+import net.opatry.tasks.DoneTaskPosition
 import net.opatry.tasks.data.entity.TaskEntity
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -35,21 +36,21 @@ class TaskSortingTest {
     fun `minimum completed date sorting position`() {
         // minimum timestamp sorting value (1970-01-01T00:00:00Z)
         val tMin = LocalDateTime(1970, 1, 1, 0, 0, 0).toInstant(TimeZone.UTC)
-        assertEquals("09999999999999999999", tMin.asCompletedTaskPosition())
+        assertEquals("09999999999999999999", DoneTaskPosition.fromCompletionDate(tMin).value)
     }
 
     @Test
     fun `arbitrary completed date sorting position`() {
         // an arbitrary timestamp (2024-10-29T15:54:12Z)
         val t = LocalDateTime(2024, 10, 29, 15, 54, 12).toInstant(TimeZone.UTC)
-        assertEquals("09999998269782747999", t.asCompletedTaskPosition())
+        assertEquals("09999998269782747999", DoneTaskPosition.fromCompletionDate(t).value)
     }
 
     @Test
     fun `maximum completed date sorting position`() {
         // RFC 3339 timestamp supposed maximum value (9999-12-31T23:59:59Z)
         val tMax = LocalDateTime(9999, 12, 31, 23, 59, 59).toInstant(TimeZone.UTC)
-        assertEquals("09999746597699200999", tMax.asCompletedTaskPosition())
+        assertEquals("09999746597699200999", DoneTaskPosition.fromCompletionDate(tMax).value)
     }
 
     @Test

--- a/tasks-core/src/jvmMain/kotlin/net/opatry/tasks/TaskPosition.jvm.kt
+++ b/tasks-core/src/jvmMain/kotlin/net/opatry/tasks/TaskPosition.jvm.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+package net.opatry.tasks
+
+import kotlinx.datetime.Instant
+import java.math.BigInteger
+
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+actual class TodoTaskPosition private constructor(internal val rawValue: BigInteger) : TaskPosition {
+    actual override val value: String
+        get() = rawValue.toString().padStart(20, '0')
+
+    actual companion object {
+        actual fun fromIndex(index: Int): TodoTaskPosition {
+            return TodoTaskPosition(BigInteger.valueOf(index.toLong()))
+        }
+
+        actual fun fromPosition(position: String): TodoTaskPosition {
+            return TodoTaskPosition(BigInteger(position))
+        }
+    }
+
+    actual override fun compareTo(other: TaskPosition): Int {
+        return when (other) {
+            is TodoTaskPosition -> rawValue.compareTo(other.rawValue)
+            is DoneTaskPosition -> rawValue.compareTo(other.rawValue)
+            else -> throw IllegalArgumentException("Only TodoTaskPosition and DoneTaskPosition are supported")
+        }
+    }
+
+    actual override fun hashCode(): Int {
+        return rawValue.hashCode()
+    }
+
+    actual override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is TodoTaskPosition) return false
+        return rawValue == other.rawValue
+    }
+
+    actual override fun toString(): String = value
+}
+
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+actual class DoneTaskPosition private constructor(internal val rawValue: BigInteger) : TaskPosition {
+    actual companion object {
+        private val UpperBound = BigInteger("9999999999999999999")
+        actual fun fromCompletionDate(completionDate: Instant): DoneTaskPosition {
+            return DoneTaskPosition(UpperBound - completionDate.toEpochMilliseconds().toBigInteger())
+        }
+
+        actual fun fromPosition(position: String): DoneTaskPosition {
+            return DoneTaskPosition(BigInteger(position))
+        }
+    }
+
+    actual override val value: String
+        get() = rawValue.toString().padStart(20, '0')
+
+    actual override fun compareTo(other: TaskPosition): Int {
+        return when (other) {
+            is TodoTaskPosition -> rawValue.compareTo(other.rawValue)
+            is DoneTaskPosition -> rawValue.compareTo(other.rawValue)
+            else -> throw IllegalArgumentException("Only TodoTaskPosition and DoneTaskPosition are supported")
+        }
+    }
+
+    actual override fun hashCode(): Int {
+        return rawValue.hashCode()
+    }
+
+    actual override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DoneTaskPosition) return false
+        return rawValue == other.rawValue
+    }
+
+    actual override fun toString(): String = value
+}


### PR DESCRIPTION
### Description
To allow using non Jvm targets (like iOS), we need to abstract `BigInteger` used under the hood for task position computation.
This is also interesting to abstract a bit the concept of task position, especially to clearly express differences between Todo & Done task position and ordering of theses positions.

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
