### PR TITLE
Gradle improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,9 +42,9 @@ plugins {
 }
 
 val koverProjects = listOf(
-    projects.tasksAppShared,
-    projects.tasksCore,
-    projects.google.tasks,
+    project(":tasks-app-shared"),
+    project(":tasks-core"),
+    project(":google:tasks"),
 )
 
 dependencies {
@@ -151,7 +151,7 @@ subprojects {
         }
     }
 
-    if (project.name in koverProjects.map { it.name }) {
+    if (project in koverProjects) {
         project.afterEvaluate {
             apply(plugin = libs.plugins.kover.get().pluginId)
             kover {

--- a/google/oauth-http/build.gradle.kts
+++ b/google/oauth-http/build.gradle.kts
@@ -31,7 +31,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(projects.google.oauth)
+            api(project(":google:oauth"))
 
             implementation(libs.bundles.ktor.client)
             implementation(libs.bundles.ktor.server)

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@
 #
 kotlin.daemon.jvmargs=-Xmx3072M
 org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-org.gradle.configuration-cache=true
+#org.gradle.configuration-cache=true
 org.gradle.caching=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -54,8 +54,6 @@ dependencyResolutionManagement {
     }
 }
 
-enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
-
 rootProject.name = "Taskfolio"
 
 include(":google:oauth")

--- a/tasks-app-android/build.gradle.kts
+++ b/tasks-app-android/build.gradle.kts
@@ -161,9 +161,9 @@ dependencies {
 
     implementation(libs.play.services.auth)
 
-    implementation(projects.google.oauth)
-    implementation(projects.google.tasks)
-    implementation(projects.tasksAppShared)
+    implementation(project(":google:oauth"))
+    implementation(project(":google:tasks"))
+    implementation(project(":tasks-app-shared"))
 
     debugImplementation(libs.androidx.ui.test.manifest)
 

--- a/tasks-app-desktop/build.gradle.kts
+++ b/tasks-app-desktop/build.gradle.kts
@@ -66,9 +66,9 @@ kotlin {
         implementation(compose.material3)
         implementation(compose.desktop.currentOs)
 
-        implementation(projects.google.oauth)
-        implementation(projects.google.tasks)
-        implementation(projects.tasksAppShared)
+        implementation(project(":google:oauth"))
+        implementation(project(":google:tasks"))
+        implementation(project(":tasks-app-shared"))
 
         if (ciBuild) {
             implementation(libs.ktor.monitor.logging.no.op)

--- a/tasks-app-shared/build.gradle.kts
+++ b/tasks-app-shared/build.gradle.kts
@@ -115,9 +115,7 @@ kotlin {
             implementation(projects.tasksCore)
 
             implementation(projects.lucideIcons)
-        }
 
-        commonMain.dependencies {
             if (ciBuild) {
                 implementation(libs.ktor.monitor.logging.no.op)
             } else {

--- a/tasks-app-shared/build.gradle.kts
+++ b/tasks-app-shared/build.gradle.kts
@@ -72,7 +72,7 @@ kotlin {
         }
 
         jvmMain.dependencies {
-            implementation(projects.google.oauthHttp)
+            implementation(project(":google:oauth-http"))
         }
 
         commonMain.dependencies {
@@ -81,8 +81,8 @@ kotlin {
             api(libs.kotlinx.datetime)
             implementation(libs.bundles.ktor.client)
             implementation(libs.slf4j.nop)
-            implementation(projects.google.oauth)
-            implementation(projects.google.tasks)
+            implementation(project(":google:oauth"))
+            implementation(project(":google:tasks"))
 
             implementation(libs.androidx.room.runtime)
             implementation(libs.androidx.sqlite.bundled)
@@ -112,9 +112,9 @@ kotlin {
 
             implementation(libs.about.libraries.core)
 
-            implementation(projects.tasksCore)
+            implementation(project(":tasks-core"))
 
-            implementation(projects.lucideIcons)
+            implementation(project(":lucide-icons"))
 
             if (ciBuild) {
                 implementation(libs.ktor.monitor.logging.no.op)

--- a/tasks-core/build.gradle.kts
+++ b/tasks-core/build.gradle.kts
@@ -42,8 +42,8 @@ kotlin {
 
             api(libs.kotlinx.datetime)
             implementation(libs.bundles.ktor.client)
-            implementation(projects.google.oauth)
-            implementation(projects.google.tasks)
+            implementation(project(":google:oauth"))
+            implementation(project(":google:tasks"))
 
             implementation(libs.androidx.room.common)
         }


### PR DESCRIPTION
### Description
- Disable Gradle configuration cache, too invasive when tweaking `local.properties` values
- Merge the 2 `commonMain` dependencies section
- Get rid of Gradle `TYPESAFE_PROJECT_ACCESSORS` due to potential build time penalty
  - see https://www.zacsweers.dev/dont-use-type-safe-project-accessors-with-kotlin-gradle-dsl/

### Checklist
- [x] I have read the [CONTRIBUTING](../../blob/main/CONTRIBUTING.md) guide
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
